### PR TITLE
miscellaneous changes to port VM to Cilium repository

### DIFF
--- a/cilium.json
+++ b/cilium.json
@@ -1,7 +1,7 @@
 {
   "variables": {
     "box_basename": "ubuntu-17.04",
-    "cpus": "1",
+    "cpus": "2",
     "disk_size": "40960",
     "headless": "true",
     "iso_checksum": "ca5d9a8438e2434b9a3ac2be67b5c5fa2c1f8e3e40b954519462935195464034",
@@ -93,8 +93,10 @@
   ],
   "post-processors": [[
     {
-        "output": "../builds/{{user `box_basename`}}.{{.Provider}}.box",
-        "type": "vagrant"
+        "output": "cilium-ginkgo-{{.BuildName}}.box",
+        "type": "vagrant",
+        "compression_level": 9,
+        "keep_input_artifact": true
     }
   ]]
 }

--- a/cilium.json
+++ b/cilium.json
@@ -13,8 +13,7 @@
     "name": "ubuntu-17.04",
     "preseed_path": "preseed.cfg",
     "template": "ubuntu-17.04-amd64",
-    "version": "TIMESTAMP",
-    "cloud_token": "{{ env `VAGRANTCLOUD_TOKEN` }}"
+    "version": "TIMESTAMP"
   },
   "builders": [
     {
@@ -96,12 +95,6 @@
     {
         "output": "../builds/{{user `box_basename`}}.{{.Provider}}.box",
         "type": "vagrant"
-    },
-    {
-        "type": "vagrant-cloud",
-        "box_tag": "eloycoto/cilium",
-        "access_token": "{{user `cloud_token`}}",
-        "version": "{{ timestamp }}"
     }
   ]]
 }

--- a/provision/install.sh
+++ b/provision/install.sh
@@ -113,7 +113,7 @@ L                      = London
 O                      = cilium
 OU                     = experimental
 CN                     = cilium.io
-emailAddress           = eloy.coto@gmail.com
+emailAddress           = ian@cilium.io
 
 [ v3_req ]
 # Extensions to add to a certificate request


### PR DESCRIPTION
* change cert email
* remove Vagrant Cloud references
* Increase default number of CPUS
* Change naming scheme for resultant box
* Add compression_level and keep_input_artifact parameters / values

Signed-off by: Ian Vernon <ian@cilium.io>