### PR TITLE
Ginkgo: Using kernel 4.9 LTS instead of 4.10.

### DIFF
--- a/cilium.json
+++ b/cilium.json
@@ -84,7 +84,19 @@
         "environment_vars": [
             "HOME_DIR=/home/vagrant"
         ],
-        "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S sh '{{ .Path }}'",
+        "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
+        "expect_disconnect": true,
+        "scripts": [
+            "provision/kernel.sh"
+        ]
+    },
+    {
+        "type": "shell",
+        "environment_vars": [
+            "HOME_DIR=/home/vagrant"
+        ],
+        "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
+        "expect_disconnect": true,
         "scripts": [
             "provision/vagrant.sh",
             "provision/install.sh"

--- a/provision/install.sh
+++ b/provision/install.sh
@@ -16,13 +16,11 @@ umount /tmp/vbox;
 rm -rf /tmp/vbox;
 rm -f $HOME_DIR/*.iso;
 
+
 echo "Provision a new server"
 sudo apt-get update
 sudo apt-get install -y --allow-downgrades \
     curl jq apt-transport-https htop bmon \
-    linux-image-extra-$(uname -r) \
-    linux-image-extra-virtual \
-    linux-headers-$(uname -r) \
     linux-tools-common linux-tools-generic \
     ca-certificates \
     software-properties-common \
@@ -30,7 +28,16 @@ sudo apt-get install -y --allow-downgrades \
     dh-make clang git \
     libdistro-info-perl \
     dh-systemd build-essential \
-    llvm gcc make libc6-dev.i386 git-buildpackage
+    llvm gcc make libc6-dev.i386 git-buildpackage \
+    pkg-config bison flex
+
+#IP Route
+cd /tmp && \
+git clone -b v4.10.0 git://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git && \
+cd /tmp/iproute2 && \
+./configure && \
+make -j `getconf _NPROCESSORS_ONLN` && \
+make install
 
 #clean
 sudo apt-get remove docker docker-engine docker.io

--- a/provision/kernel.sh
+++ b/provision/kernel.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# This script installs the 4.9 Kernel from the Ubuntu Kernel PPA repository.
+# The script downloads and installs the packages from the repo. When it
+# finished, it sets the new kernel as default in the grub.
+# Finally, it reboots the virtual machine to boot using the new kernel, the
+# main reason of this is to install correctly all VirtualBox kernel modules.
+
+mkdir /tmp/deb
+cd /tmp/deb
+
+wget http://kernel.ubuntu.com/~kernel-ppa/mainline/v4.9.68/linux-image-4.9.68-040968-generic_4.9.68-040968.201712091734_amd64.deb
+wget http://kernel.ubuntu.com/~kernel-ppa/mainline/v4.9.68/linux-headers-4.9.68-040968-generic_4.9.68-040968.201712091734_amd64.deb
+wget http://kernel.ubuntu.com/~kernel-ppa/mainline/v4.9.68/linux-headers-4.9.68-040968_4.9.68-040968.201712091734_all.deb
+
+dpkg -i *.deb
+
+
+
+KERNEL="4.9"
+
+function get_grub_config {
+	gawk  'BEGIN {
+	  l=0
+	  menuindex= 1
+	  stack[t=0] = 0
+	}
+
+	function push(x) { stack[t++] = x }
+
+	function pop() { if (t > 0) { return stack[--t] } else { return "" }  }
+
+	{
+
+	if( $0 ~ /.*menu.*{.*/ )
+	{
+	  push( $0 )
+	  l++;
+
+	} else if( $0 ~ /.*{.*/ )
+	{
+	  push( $0 )
+
+	} else if( $0 ~ /.*}.*/ )
+	{
+	  X = pop()
+	  if( X ~ /.*menu.*{.*/ )
+	  {
+		 l--;
+		 match( X, /^[^'\'']*'\''([^'\'']*)'\''.*$/, arr )
+
+		 if( l == 0 )
+		 {
+		   print menuindex ": " arr[1]
+		   menuindex++
+		   submenu=0
+		 } else
+		 {
+		   print "  " (menuindex-1) ">" submenu " " arr[1]
+		   submenu++
+		 }
+	  }
+	}
+
+	}' /boot/grub/grub.cfg
+
+}
+
+grub_entry=$(get_grub_config | grep $KERNEL | grep -v "recovery" | awk '{ print $1 }')
+
+echo "Default grub entry is $grub_entry"
+grub-set-default "$grub_entry"
+sed -i 's/GRUB_DEFAULT=.*/GRUB_DEFAULT=saved/g' /etc/default/grub
+update-grub
+reboot


### PR DESCRIPTION
- Install 4.9 kernel on base image
- Updated grub to boot from 4.9 kernel

Related to https://github.com/cilium/cilium/issues/2291

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>