### PR TITLE
Ginkgo: Using kernel 4.9 LTS instead of 4.10.

### DIFF
--- a/cilium.json
+++ b/cilium.json
@@ -84,7 +84,19 @@
         "environment_vars": [
             "HOME_DIR=/home/vagrant"
         ],
-        "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S sh '{{ .Path }}'",
+        "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
+        "expect_disconnect": true,
+        "scripts": [
+            "provision/kernel.sh"
+        ]
+    },
+    {
+        "type": "shell",
+        "environment_vars": [
+            "HOME_DIR=/home/vagrant"
+        ],
+        "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
+        "expect_disconnect": true,
         "scripts": [
             "provision/vagrant.sh",
             "provision/install.sh"

--- a/provision/install.sh
+++ b/provision/install.sh
@@ -4,6 +4,11 @@ GOLANG_VERSION="1.8.3"
 ETCD_VERSION="v3.1.0"
 CERTS_DIR=/certs/
 
+CLANG_DIR="clang+llvm-3.8.1-x86_64-linux-gnu-ubuntu-16.04"
+CLANG_FILE="${CLANG_DIR}.tar.xz"
+CLANG_URL="http://releases.llvm.org/3.8.1/$CLANG_FILE"
+CLANGROOT=/usr/local/clang
+
 #If VBOX server
 VER="`cat /home/vagrant/.vbox_version`";
 ISO="VBoxGuestAdditions_$VER.iso";
@@ -16,21 +21,36 @@ umount /tmp/vbox;
 rm -rf /tmp/vbox;
 rm -f $HOME_DIR/*.iso;
 
+
 echo "Provision a new server"
 sudo apt-get update
 sudo apt-get install -y --allow-downgrades \
     curl jq apt-transport-https htop bmon \
-    linux-image-extra-$(uname -r) \
-    linux-image-extra-virtual \
-    linux-headers-$(uname -r) \
     linux-tools-common linux-tools-generic \
-    ca-certificates \
+    ca-certificates libelf-dev \
     software-properties-common \
     dh-golang devscripts fakeroot \
-    dh-make clang git \
+    dh-make libmnl-dev git \
     libdistro-info-perl \
     dh-systemd build-essential \
-    llvm gcc make libc6-dev.i386 git-buildpackage
+    gcc make libc6-dev.i386 git-buildpackage \
+    pkg-config bison flex
+
+#IP Route
+cd /tmp && \
+git clone -b v4.14.0 git://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git && \
+cd /tmp/iproute2 && \
+./configure && \
+make -j `getconf _NPROCESSORS_ONLN` && \
+make install
+
+wget --quiet $CLANG_URL
+mkdir -p /usr/local
+tar -C /usr/local -xJf $CLANG_FILE
+ln -s /usr/local/$CLANG_DIR $CLANGROOT
+rm $CLANG_FILE
+
+ln -s $CLANGROOT/bin/* /usr/local/bin/
 
 #clean
 sudo apt-get remove docker docker-engine docker.io

--- a/provision/kernel.sh
+++ b/provision/kernel.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# This script installs kernel 4.9.68 and when it finished sets the installed
+# kernel as default in the grub.
+
+mkdir /tmp/deb
+cd /tmp/deb
+
+wget http://kernel.ubuntu.com/~kernel-ppa/mainline/v4.9.68/linux-image-4.9.68-040968-generic_4.9.68-040968.201712091734_amd64.deb
+wget http://kernel.ubuntu.com/~kernel-ppa/mainline/v4.9.68/linux-headers-4.9.68-040968-generic_4.9.68-040968.201712091734_amd64.deb
+wget http://kernel.ubuntu.com/~kernel-ppa/mainline/v4.9.68/linux-headers-4.9.68-040968_4.9.68-040968.201712091734_all.deb
+
+dpkg -i *.deb
+
+
+
+KERNEL="4.9"
+
+function get_grub_config {
+	gawk  'BEGIN {
+	  l=0
+	  menuindex= 1
+	  stack[t=0] = 0
+	}
+
+	function push(x) { stack[t++] = x }
+
+	function pop() { if (t > 0) { return stack[--t] } else { return "" }  }
+
+	{
+
+	if( $0 ~ /.*menu.*{.*/ )
+	{
+	  push( $0 )
+	  l++;
+
+	} else if( $0 ~ /.*{.*/ )
+	{
+	  push( $0 )
+
+	} else if( $0 ~ /.*}.*/ )
+	{
+	  X = pop()
+	  if( X ~ /.*menu.*{.*/ )
+	  {
+		 l--;
+		 match( X, /^[^'\'']*'\''([^'\'']*)'\''.*$/, arr )
+
+		 if( l == 0 )
+		 {
+		   print menuindex ": " arr[1]
+		   menuindex++
+		   submenu=0
+		 } else
+		 {
+		   print "  " (menuindex-1) ">" submenu " " arr[1]
+		   submenu++
+		 }
+	  }
+	}
+
+	}' /boot/grub/grub.cfg
+
+}
+
+grub_entry=$(get_grub_config | grep $KERNEL | grep -v "recovery" | awk '{ print $1 }')
+
+echo "Default grub entry is '$grub_entry'"
+grub-set-default "$grub_entry"
+sed -i 's/GRUB_DEFAULT=.*/GRUB_DEFAULT=saved/g' /etc/default/grub
+update-grub
+reboot


### PR DESCRIPTION
Hi @ianvernon,

Today I had a chat with @borkmann, and the problem with the new image was the LLVM version, sorted in the configuration. 

It is working now.

- Install 4.9 kernel 
- Updated grub to boot from 4.9 kernel
- Install 4.14 IP route
- Install 3.8.1 LLVM+Clang

Related to https://github.com/cilium/cilium/issues/2291

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>