### PR TITLE
opensuse: Add lsb-release package

### DIFF
--- a/http/opensuse.xml
+++ b/http/opensuse.xml
@@ -156,6 +156,8 @@
       <package>libtool</package>
       <package>libyaml-devel</package>
       <package>llvm</package>
+      <package>lsb</package>
+      <package>lsb-release</package>
       <package>m4</package>
       <package>make</package>
       <package>protobuf-c</package>


### PR DESCRIPTION
lsb-release is needed to detect a distribution in Vagrant
provisioning scripts.

Ref #2497