### PR TITLE
Jenkinsfile: Fix issues with env.GIT_BRANCH

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
         stage('Validate Upload'){
             when {
                 expression {
-                    return env.GIT_BRANCH == 'origin/master';
+                    return env.GIT_BRANCH == 'master';
                 }
             }
             steps {


### PR DESCRIPTION
On build #1 the GIT_BRANCH is "master" instead of origin/master so it
didn't upload the build to vagrantcloud.

Log:

```
[lium_packer-ci-build_master-2HHAHSGBB76OCIXFXBDOFKDLILAPWMGN6BTSF3S2RV2RZIG6BB2Q] Running shell script
+ printenv
JENKINS_HOME=/var/jenkins_home
MAIL=/var/mail/root
USER=root
RUN_CHANGES_DISPLAY_URL=https://jenkins.cilium.io/job/cilium/job/packer-ci-build/job/master/1/display/redirect?page=changes
NODE_LABELS=ginkgo jenkins-node-0 nightly vagrant
HUDSON_URL=https://jenkins.cilium.io/
GIT_COMMIT=3d91319c38086ef652593a19a95c915fc3df5e8c
SHLVL=1
OLDPWD=/root
HOME=/root
BUILD_URL=https://jenkins.cilium.io/job/cilium/job/packer-ci-build/job/master/1/
HUDSON_COOKIE=d46b9225-cfcc-4e6f-b543-1fb83a356d5b
JENKINS_SERVER_COOKIE=durable-b799f4220dde52fc3a29c743d0491d98
WORKSPACE=/home/jenkins/workspace/lium_packer-ci-build_master-2HHAHSGBB76OCIXFXBDOFKDLILAPWMGN6BTSF3S2RV2RZIG6BB2Q
JQ=.["post-processors"][0] |= map(select(.type != "vagrant-cloud"))
LOGNAME=root
NODE_NAME=jenkins-node-0
_=/usr/bin/java
STAGE_NAME=Opensuse
EXECUTOR_NUMBER=0
GIT_BRANCH=master
XDG_SESSION_ID=5
BUILD_DISPLAY_NAME=#1
HUDSON_HOME=/var/jenkins_home
JOB_BASE_NAME=master
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/usr/local/go/bin:/root/go/bin
BUILD_ID=1
XDG_RUNTIME_DIR=/run/user/0
BUILD_TAG=jenkins-cilium-packer-ci-build-master-1
LANG=en_US.UTF-8
JENKINS_URL=https://jenkins.cilium.io/
JOB_URL=https://jenkins.cilium.io/job/cilium/job/packer-ci-build/job/master/
GIT_URL=https://github.com/cilium/packer-ci-build.git
BUILD_NUMBER=1
JENKINS_NODE_COOKIE=bb9d0aee-5930-4cb3-8904-8a07c2651bb3
SHELL=/bin/bash
RUN_DISPLAY_URL=https://jenkins.cilium.io/job/cilium/job/packer-ci-build/job/master/1/display/redirect
HUDSON_SERVER_COOKIE=693c250bfb7e85bf
JOB_DISPLAY_URL=https://jenkins.cilium.io/job/cilium/job/packer-ci-build/job/master/display/redirect
JOB_NAME=cilium/packer-ci-build/master
PWD=/home/jenkins/workspace/lium_packer-ci-build_master-2HHAHSGBB76OCIXFXBDOFKDLILAPWMGN6BTSF3S2RV2RZIG6BB2Q
SSH_CONNECTION=54.148.123.155 32926 147.75.68.25 22
BRANCH_NAME=master
```

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>