### PR TITLE
Disabled systemd-resolved service

### DIFF
--- a/provision/ubuntu/install.sh
+++ b/provision/ubuntu/install.sh
@@ -139,3 +139,12 @@ sudo systemctl start etcd
 
 sudo -u vagrant -E sh -c 'echo "export PATH=$PATH" >> "${HOME_DIR}/.bashrc"'
 echo "export PATH=$PATH" >> "/root/.bashrc"
+
+# Clean all downloaded packages
+sudo apt-get -y clean
+sudo apt-get -y autoclean
+
+# Disable systemd-resolved service
+# https://github.com/cilium/cilium/issues/2750
+sudo systemctl disable systemd-resolved.service
+sudo service systemd-resolved stop


### PR DESCRIPTION
- Disabled systemd-resolved service
<https://github.com/cilium/cilium/issues/2750>
- Clean all ubuntu cache packages before upload to vagrantcloud

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>