### PR TITLE
opensuse: Add missing packages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,16 @@ pipeline {
     }
 
     stages {
+        stage('Opensuse') {
+            steps {
+                sh 'printenv'
+                withCredentials([string(credentialsId: 'vagrantcloud token', variable: 'VAGRANTCLOUD_TOKEN')]) {
+                    sh 'echo ${JQ}'
+                    sh 'git submodule update --init --recursive'
+                    sh 'make build DISTRIBUTION=opensuse'
+                }
+            }
+        }
         stage('Ubuntu') {
             steps {
                 withCredentials([string(credentialsId: 'vagrantcloud token', variable: 'VAGRANTCLOUD_TOKEN')]) {

--- a/cilium-opensuse.json
+++ b/cilium-opensuse.json
@@ -85,6 +85,7 @@
         "third_party/openSUSE-vagrant/scripts/base/vagrant.sh",
         "third_party/openSUSE-vagrant/scripts/base/cleanup.sh",
         "provision/vagrant.sh",
+        "provision/opensuse/install.sh",
         "provision/opensuse/docker.sh",
         "provision/golang.sh",
         "provision/registry.sh",

--- a/http/opensuse.xml
+++ b/http/opensuse.xml
@@ -114,6 +114,7 @@
     </patterns>
 
     <packages config:type="list">
+      <package>autoconf</package>
       <package>automake</package>
       <package>bc</package>
       <package>binutils</package>
@@ -138,6 +139,8 @@
       <package>gcc-32bit</package>
       <package>gcc-c++</package>
       <package>gcc-c++-32bit</package>
+      <package>gettext-runtime</package>
+      <package>gettext-tools</package>
       <package>git</package>
       <package>glibc-devel</package>
       <package>glibc-devel-32bit</package>
@@ -150,9 +153,11 @@
       <package>less</package>
       <package>libelf-devel</package>
       <package>libmnl-devel</package>
+      <package>ncurses5-devel</package>
       <package>libopenssl-devel</package>
       <package>libprotobuf-c-devel</package>
       <package>libprotobuf-c1</package>
+      <package>libselinux-devel</package>
       <package>libtool</package>
       <package>libyaml-devel</package>
       <package>llvm</package>
@@ -167,11 +172,15 @@
       <package>python-xml</package>
       <package>python3-devel</package>
       <package>python3-pip</package>
+      <package>python3-Sphinx</package>
+      <package>python3-sphinxcontrib-httpdomain</package>
       <package>rsync</package>
+      <package>slang-devel</package>
       <package>socat</package>
       <package>sudo</package>
       <package>tmux</package>
       <package>unzip</package>
+      <package>util-linux</package>
       <package>vim</package>
       <package>wget</package>
       <package>yast2-services-manager</package>

--- a/http/opensuse.xml
+++ b/http/opensuse.xml
@@ -144,7 +144,6 @@
       <package>git</package>
       <package>glibc-devel</package>
       <package>glibc-devel-32bit</package>
-      <package>go1.8</package>
       <package>grub2</package>
       <package>htop</package>
       <package>iproute2</package>

--- a/provision/opensuse/install.sh
+++ b/provision/opensuse/install.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -eux
+
+sudo zypper -n ar -r https://download.opensuse.org/repositories/home:/mrostecki/openSUSE_Tumbleweed/home:mrostecki.repo
+sudo zypper -n --gpg-auto-import-key in --no-recommends \
+        python3-sphinxcontrib-openapi \
+    && sudo zypper clean

--- a/provision/opensuse/install.sh
+++ b/provision/opensuse/install.sh
@@ -2,7 +2,9 @@
 
 set -eux
 
+sudo zypper -n ar -r https://download.opensuse.org/repositories/devel:/languages:/go/openSUSE_Factory/devel:languages:go.repo
 sudo zypper -n ar -r https://download.opensuse.org/repositories/home:/mrostecki/openSUSE_Tumbleweed/home:mrostecki.repo
 sudo zypper -n --gpg-auto-import-key in --no-recommends \
+        go1.9 \
         python3-sphinxcontrib-openapi \
     && sudo zypper clean


### PR DESCRIPTION
Due to recent changes related to Envoy build, the following
dependencies needs to be installed:

- autoconf
- gettext-runtime
- gettext-tools
- ncurses5-devel
- libselinux-devel
- python3-Sphinx
- python3-sphinxcontrib-httpdomain
- python3-sphinxcontrib-openapi
- slang-devel
- util-linux

Signed-off-by: Michal Rostecki <mrostecki@suse.com>