### PR TITLE
Ubuntu: Fix issues with the DNS

### DIFF
--- a/provision/ubuntu/install.sh
+++ b/provision/ubuntu/install.sh
@@ -148,3 +148,8 @@ sudo apt-get -y autoclean
 # https://github.com/cilium/cilium/issues/2750
 sudo systemctl disable systemd-resolved.service
 sudo service systemd-resolved stop
+
+sudo tee /etc/resolv.conf <<EOF
+nameserver 8.8.8.8
+nameserver 8.8.4.4
+EOF


### PR DESCRIPTION
Fix issues when try to install go-bindata:

```
[0;32m    virtualbox-iso: # cd .; git clone https://github.com/cilium/go-bindata /home/vagrant/go/src/github.com/cilium/go-bindata[0m
[0;32m    virtualbox-iso: Cloning into '/home/vagrant/go/src/github.com/cilium/go-bindata'...[0m
[0;32m    virtualbox-iso: fatal: unable to access 'https://github.com/cilium/go-bindata/': Could not resolve host: github.com[0m
[0;32m    virtualbox-iso: package github.com/cilium/go-bindata/...: exit status 128[0m
```

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>