### PR TITLE
add patch to pre-build envoy with experimental_strict_action_env

### DIFF
--- a/provision/envoy.sh
+++ b/provision/envoy.sh
@@ -12,11 +12,29 @@ sudo -E mkdir -p "${GOPATH}/src/github.com/cilium"
 sudo -E chmod 755 "${GOPATH}/src/github.com/cilium"
 sudo -E chown vagrant:vagrant "${GOPATH}" -R
 
+# TODO delete me once https://github.com/cilium/cilium/pull/2826 is merged
+cat > ${HOME}/diff.patch <<EOF
+diff --git a/envoy/Makefile b/envoy/Makefile
+index 582f51d3b..20a8af4b6 100644
+--- a/envoy/Makefile
++++ b/envoy/Makefile
+@@ -77,7 +77,7 @@ ifdef PKG_BUILD
+ BAZEL_BUILD_OPTS = --spawn_strategy=standalone --genrule_strategy=standalone
+ all: clean-bins release
+ else
+-BAZEL_BUILD_OPTS =
++BAZEL_BUILD_OPTS = --experimental_strict_action_env
+
+ all: clean-bins envoy $(GO_TARGETS)
+ endif
+EOF
+
 sudo -u vagrant -E sh -c "\
     cd \"${GOPATH}/src/github.com/cilium\" && \
     git clone -b master https://github.com/cilium/cilium.git && \
     cd cilium && \
     git submodule update --init --recursive && \
+    patch -p1 < ${HOME}/diff.patch && \
     cd envoy && \
     grep \"ENVOY_SHA[ \t]*=\" WORKSPACE | cut -d \\\" -f 2 >SOURCE_VERSION && \
     cat SOURCE_VERSION && \


### PR DESCRIPTION
We need to add this patch temporarily so https://github.com/cilium/cilium/pull/2826 succeeds with its tests and we merge it into the repository