### PR TITLE
Packer-CI: Send the images to Amazon S3 instead of vagrantcloud. 

### DIFF
--- a/cilium-opensuse.json
+++ b/cilium-opensuse.json
@@ -11,8 +11,8 @@
     "name": "opensuse-tumbleweed",
     "template": "opensuse-tumbleweed-amd64",
     "version": "TIMESTAMP",
-	"cloud_token": "{{ env `VAGRANTCLOUD_TOKEN` }}",
-	"BUILD_ID": "{{ env `BUILD_ID` }}"
+    "cloud_token": "{{ env `VAGRANTCLOUD_TOKEN` }}",
+    "BUILD_ID": "{{ env `BUILD_ID` }}"
   },
   "builders": [
     {
@@ -94,19 +94,29 @@
       ]
     }
   ],
-  "post-processors": [[
-    {
-      "output": "cilium-ginkgo-opensuse-{{.BuildName}}.box",
+  "post-processors": [
+    [{
+      "output": "cilium-ginkgo-opensuse-{{user `BUILD_ID`}}.box",
       "type": "vagrant",
       "compression_level": 9,
       "keep_input_artifact": false
-    },
-    {
+    }, {
+      "type": "shell-local",
+      "inline": [
+        "/usr/local/bin/aws s3 cp cilium-ginkgo-opensuse-{{user `BUILD_ID`}}.box s3://ciliumvagrantbaseboxes/"
+      ]
+    }],[{
+      "output": "cilium-ginkgo-opensuse-{{user `BUILD_ID`}}.box",
+      "type": "vagrant",
+      "compression_level": 9,
+      "keep_input_artifact": false
+    },{
       "type": "vagrant-cloud",
       "box_tag": "cilium/opensuse",
       "access_token": "{{user `cloud_token`}}",
-      "version": "{{ user `BUILD_ID` }}"
-    }
-  ]]
+      "version": "{{ user `BUILD_ID` }}",
+      "box_download_url": "https://s3-us-west-2.amazonaws.com/ciliumvagrantbaseboxes/cilium-ginkgo-opensuse-{{user `BUILD_ID`}}.box"
+    }]
+  ]
 }
 

--- a/cilium-ubuntu.json
+++ b/cilium-ubuntu.json
@@ -14,8 +14,8 @@
     "preseed_path": "preseed.cfg",
     "template": "ubuntu-17.10-amd64",
     "version": "TIMESTAMP",
-	"cloud_token": "{{ env `VAGRANTCLOUD_TOKEN` }}",
-	"BUILD_ID": "{{ env `BUILD_ID` }}"
+    "cloud_token": "{{ env `VAGRANTCLOUD_TOKEN` }}",
+    "BUILD_ID": "{{ env `BUILD_ID` }}"
   },
   "builders": [
     {
@@ -88,13 +88,11 @@
       "scripts": [
           "provision/ubuntu/kernel.sh"
       ]
-    },
-    {
+    },{
       "type": "file",
       "source": "provision/env.bash",
       "destination": "/tmp/env.bash"
-    },
-    {
+    },{
       "type": "shell",
       "environment_vars": [
         "ENV_FILEPATH=/tmp/env.bash"
@@ -111,19 +109,28 @@
       ]
     }
   ],
-  "post-processors": [[
-    {
-      "output": "cilium-ginkgo-ubuntu-{{.BuildName}}.box",
+  "post-processors": [
+    [{
+      "output": "cilium-ginkgo-ubuntu-{{user `BUILD_ID`}}.box",
       "type": "vagrant",
       "compression_level": 9,
       "keep_input_artifact": false
-    },
-    {
+    }, {
+      "type": "shell-local",
+      "inline": [
+        "/usr/local/bin/aws s3 cp cilium-ginkgo-ubuntu-{{user `BUILD_ID`}}.box s3://ciliumvagrantbaseboxes/"
+      ]
+    }],[{
+      "output": "cilium-ginkgo-ubuntu-{{user `BUILD_ID`}}.box",
+      "type": "vagrant",
+      "compression_level": 9,
+      "keep_input_artifact": false
+    },{
       "type": "vagrant-cloud",
       "box_tag": "cilium/ubuntu",
       "access_token": "{{user `cloud_token`}}",
-      "version": "{{ user `BUILD_ID` }}"
-    }
-  ]]
+      "version": "{{ user `BUILD_ID` }}",
+      "box_download_url": "https://s3-us-west-2.amazonaws.com/ciliumvagrantbaseboxes/cilium-ginkgo-ubuntu-{{user `BUILD_ID`}}.box"
+    }]
+  ]
 }
-


### PR DESCRIPTION
Use Amazon S3 as datastore and publish the URL to VagrantCloud. 

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>