### PR TITLE
opensuse: Install bazel, recommonmark and sphinx-tabs from RPMs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ARGS =
 DISTRIBUTION ?= ubuntu
-JQ ?= .["post-processors"][0] |= map(select(.type != "vagrant-cloud"))
+JQ ?= del(."post-processors"[])
 
 ifeq ($(DISTRIBUTION), ubuntu)
 JSON_FILE = cilium-ubuntu.json

--- a/http/opensuse.xml
+++ b/http/opensuse.xml
@@ -171,6 +171,7 @@
       <package>python-xml</package>
       <package>python3-devel</package>
       <package>python3-pip</package>
+      <package>python3-recommonmark</package>
       <package>python3-Sphinx</package>
       <package>python3-sphinxcontrib-httpdomain</package>
       <package>rsync</package>

--- a/provision/envoy.sh
+++ b/provision/envoy.sh
@@ -14,29 +14,11 @@ sudo -E mkdir -p "${GOPATH}/src/github.com/cilium"
 sudo -E chmod 755 "${GOPATH}/src/github.com/cilium"
 sudo -E chown vagrant:vagrant "${GOPATH}" -R
 
-# TODO delete me once https://github.com/cilium/cilium/pull/2826 is merged
-cat > ${HOME}/diff.patch <<EOF
-diff --git a/envoy/Makefile b/envoy/Makefile
-index 2be0db3a5..c7c547eeb 100644
---- a/envoy/Makefile
-+++ b/envoy/Makefile
-@@ -78,7 +78,7 @@ BAZEL_BUILD_OPTS = --spawn_strategy=standalone --genrule_strategy=standalone
- all: clean-bins release
- else
- BAZEL_OPTS ?=
--BAZEL_BUILD_OPTS =
-+BAZEL_BUILD_OPTS = --experimental_strict_action_env
-
- all: clean-bins envoy \$(GO_TARGETS)
- endif
-EOF
-
 sudo -u vagrant -E sh -c "\
     cd \"${GOPATH}/src/github.com/cilium\" && \
     git clone -b master https://github.com/cilium/cilium.git && \
     cd cilium && \
     git submodule update --init --recursive && \
-    patch -p1 < ${HOME}/diff.patch && \
     cd envoy && \
     grep \"ENVOY_SHA[ \t]*=\" WORKSPACE | cut -d \\\" -f 2 >SOURCE_VERSION && \
     cat SOURCE_VERSION && \

--- a/provision/envoy.sh
+++ b/provision/envoy.sh
@@ -4,12 +4,6 @@ source "${ENV_FILEPATH}"
 
 set -e
 
-wget -nv "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"
-chmod +x "bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"
-sudo -E "./bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"
-sudo -E mv /usr/local/bin/bazel /usr/bin
-rm "bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"
-
 sudo -E mkdir -p "${GOPATH}/src/github.com/cilium"
 sudo -E chmod 755 "${GOPATH}/src/github.com/cilium"
 sudo -E chown vagrant:vagrant "${GOPATH}" -R

--- a/provision/opensuse/install.sh
+++ b/provision/opensuse/install.sh
@@ -4,7 +4,10 @@ set -eux
 
 sudo zypper -n ar -r https://download.opensuse.org/repositories/devel:/languages:/go/openSUSE_Factory/devel:languages:go.repo
 sudo zypper -n ar -r https://download.opensuse.org/repositories/home:/mrostecki/openSUSE_Tumbleweed/home:mrostecki.repo
+sudo zypper -n ar -r https://download.opensuse.org/repositories/home:/mrostecki:/branches:/devel:/tools:/building/openSUSE_Factory/home:mrostecki:branches:devel:tools:building.repo
 sudo zypper -n --gpg-auto-import-key in --no-recommends \
+        bazel \
         go1.9 \
+        python3-sphinx-tabs \
         python3-sphinxcontrib-openapi \
     && sudo zypper clean

--- a/provision/ubuntu/install.sh
+++ b/provision/ubuntu/install.sh
@@ -155,3 +155,10 @@ sudo tee /etc/resolv.conf <<EOF
 nameserver 8.8.8.8
 nameserver 8.8.4.4
 EOF
+
+# Install bazel
+wget -nv "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"
+chmod +x "bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"
+sudo -E "./bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"
+sudo -E mv /usr/local/bin/bazel /usr/bin
+rm "bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"


### PR DESCRIPTION
This change installs bazel, recommonmark and sphinx-tabs from RPMs
in openSUSE and installs bazel from "upstream" scripts only in
Ubuntu.

Signed-off-by: Michal Rostecki <mrostecki@suse.com>