### PR TITLE
openSUSE fixes

### DIFF
--- a/cilium-opensuse.json
+++ b/cilium-opensuse.json
@@ -87,6 +87,7 @@
         "provision/vagrant.sh",
         "provision/opensuse/install.sh",
         "provision/opensuse/docker.sh",
+        "provision/opensuse/etcd.sh",
         "provision/swap.sh",
         "provision/golang.sh",
         "provision/registry.sh",

--- a/http/opensuse.xml
+++ b/http/opensuse.xml
@@ -144,6 +144,7 @@
       <package>git</package>
       <package>glibc-devel</package>
       <package>glibc-devel-32bit</package>
+      <package>go1.9</package>
       <package>grub2</package>
       <package>htop</package>
       <package>iproute2</package>

--- a/provision/opensuse/etcd.sh
+++ b/provision/opensuse/etcd.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -eu
+
+mkdir -p /var/etcd/cilium
+chown -R etcd:etcd /var/etcd/cilium
+
+sudo sed -i 's+ETCD_DATA_DIR=.*$+ETCD_DATA_DIR=/var/etcd/cilium+g' /etc/sysconfig/etcd
+sudo sed -i 's+ETCD_LISTEN_CLIENT_URLS=.*$+ETCD_LISTEN_CLIENT_URLS="http://0.0.0.0:9732"+g' /etc/sysconfig/etcd
+sudo sed -i 's+#ETCD_LISTEN_PEER_URLS=.*$+ETCD_LISTEN_PEER_URLS="http://0.0.0.0:9733"+g' /etc/sysconfig/etcd
+sudo sed -i 's+#ETCD_INITIAL_ADVERTISE_PEER_URLS=.*$+ETCD_INITIAL_ADVERTISE_PEER_URLS="http://localhost:9733"+g' /etc/sysconfig/etcd
+sudo sed -i 's+#ETCD_INITIAL_CLUSTER=.*$+ETCD_INITIAL_CLUSTER="default=http://localhost:9733"+g' /etc/sysconfig/etcd
+sudo sed -i 's+ETCD_ADVERTISE_CLIENT_URLS=.*$+ETCD_ADVERTISE_CLIENT_URLS="http://localhost:9732"+g' /etc/sysconfig/etcd
+
+sudo systemctl enable etcd
+sudo systemctl start etcd

--- a/provision/opensuse/install.sh
+++ b/provision/opensuse/install.sh
@@ -2,12 +2,9 @@
 
 set -eux
 
-sudo zypper -n ar -r https://download.opensuse.org/repositories/devel:/languages:/go/openSUSE_Factory/devel:languages:go.repo
-sudo zypper -n ar -r https://download.opensuse.org/repositories/home:/mrostecki/openSUSE_Tumbleweed/home:mrostecki.repo
-sudo zypper -n ar -r https://download.opensuse.org/repositories/home:/mrostecki:/branches:/devel:/tools:/building/openSUSE_Factory/home:mrostecki:branches:devel:tools:building.repo
+sudo zypper -n ar -r https://download.opensuse.org/repositories/home:/mrostecki:/cilium/openSUSE_Tumbleweed/home:mrostecki:cilium.repo
 sudo zypper -n --gpg-auto-import-key in --no-recommends \
         bazel \
-        go1.9 \
         python3-sphinx-tabs \
         python3-sphinxcontrib-openapi \
     && sudo zypper clean


### PR DESCRIPTION
opensuse: Use home:mrostecki:cilium as the only external repo

Go 1.9 is already shipped in openSUSE Tumbleweed.

Every other dependency which is needed for building cilium and
is not provided in the officcial Tumbleweed repo was moved
to home:mrostecki:cilium[1].

[1] https://build.opensuse.org/project/show/home:mrostecki:cilium

Signed-off-by: Michal Rostecki <mrostecki@suse.com>

---

opensuse: Configure etcd service with 9732 and 9733 ports

Signed-off-by: Michal Rostecki <mrostecki@suse.com>