### PR TITLE
Upgrade Bazel to version 0.11.0

### DIFF
--- a/provision/env.bash
+++ b/provision/env.bash
@@ -3,7 +3,7 @@
 export GOLANG_VERSION="1.9.3"
 export ETCD_VERSION="v3.1.0"
 export DOCKER_COMPOSE_VERSION="1.16.1"
-export BAZEL_VERSION="0.10.1"
+export BAZEL_VERSION="0.11.0"
 
 export CLANG_ROOT=/usr/local/clang
 export HOME_DIR=/home/vagrant


### PR DESCRIPTION
Upgrade Bazel to allow compiling the Istio Envoy filters (https://github.com/cilium/cilium/pull/3035).

Signed-off-by: Romain Lenglet <romain@covalent.io>