### PR TITLE
Add cilium/starwars image

### DIFF
--- a/provision/pull-images.sh
+++ b/provision/pull-images.sh
@@ -2,13 +2,13 @@
 
 source "${ENV_FILEPATH}"
 
-set -e 
+set -e
 
 for img in tgraf/netperf httpd cilium/demo-httpd \
   cilium/demo-client borkmann/misc \
   registry busybox:latest quay.io/coreos/etcd:v3.1.0 \
   digitalwonderland/zookeeper wurstmeister/kafka \
-  cilium/kafkaclient2 ; do
+  cilium/kafkaclient2 cilium/starwars; do
   sudo docker pull $img &
 done
 


### PR DESCRIPTION
Jenkins build are slow because need to donwload that image.

https://jenkins.cilium.io/job/Ginkgo-CI-Tests-Pipeline/1812/testReport/k8s-1/9/K8sValidatedDemosTest_Tests_Star_Wars_Demo/

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>