### PR TITLE
opensuse: Create only one root xfs partition

### DIFF
--- a/http/opensuse.xml
+++ b/http/opensuse.xml
@@ -70,7 +70,14 @@
   <partitioning config:type="list">
     <drive>
       <device>/dev/sda</device>
-      <initialize config:type="boolean">true</initialize>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">false</create>
+          <format config:type="boolean">true</format>
+          <mount>/</mount>
+          <filesystem config:type="symbol">xfs</filesystem>
+        </partition>
+      </partitions>
       <use>all</use>
     </drive>
   </partitioning>


### PR DESCRIPTION
By default, AutoYaST creates a small swap partition. Kubernetes
and kubeadm expect swap to be disables, so here we excplicitly
create only one partition with / mountpoint.

Signed-off-by: Michal Rostecki <mrostecki@suse.com>