### PR TITLE
Ubuntu-next: Add the kernel net-next in ubuntu base image

### DIFF
--- a/Jenkinsfile-next
+++ b/Jenkinsfile-next
@@ -1,0 +1,38 @@
+def vagrantUpload = { String branch ->
+  if (branch == "origin/master" || branch == "master") {
+    return '.'
+  } else {
+    return 'del(."post-processors"[])'
+  }
+}
+
+pipeline {
+    agent {
+        label 'vagrant'
+    }
+    options {
+        timeout(time: 200, unit: 'MINUTES')
+        timestamps()
+    }
+
+    environment {
+        JQ = vagrantUpload(env.GIT_BRANCH)
+        VAGRANTCLOUD_TOKEN = credentials('vagrantcloud token')
+        AWS_ACCESS_KEY_ID = credentials('AWS_ACCESS_KEY_ID')
+        AWS_SECRET_ACCESS_KEY = credentials('AWS_SECRET_ACCESS_KEY')
+    }
+
+    stages {
+        stage('Ubuntu') {
+            steps {
+                sh 'make clean DISTRIBUTION=ubuntu-next'
+                sh 'make build DISTRIBUTION=ubuntu-next'
+            }
+        }
+    }
+    post {
+        always {
+           cleanWs()
+        }
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ BOX_FILE = cilium-ginkgo-opensuse-virtualbox-iso.box
 ISO_URL = http://widehat.opensuse.org/tumbleweed/iso/openSUSE-Tumbleweed-NET-x86_64-Current.iso
 ISO_CHECKSUM = $(shell $(CURDIR)/tools/opensuse-tumbleweed-checksum.sh)
 ARGS += -var iso_url=$(ISO_URL) -var iso_checksum=$(ISO_CHECKSUM)
+else ifeq ($(DISTRIBUTION), ubuntu-next)
+JSON_FILE = cilium-ubuntu-next.json
+BOX_FILE = cilium-ginkgo-virtualbox-iso-next.box
 else
 $(error "Distribution $(DISTRIBUTION) is unsupported")
 endif

--- a/cilium-ubuntu-next.json
+++ b/cilium-ubuntu-next.json
@@ -1,0 +1,143 @@
+{
+
+  "variables": {
+    "box_basename": "ubuntu-18.10",
+    "cpus": "8",
+    "disk_size": "40960",
+    "headless": "true",
+    "iso_checksum": "a5b0ea5918f850124f3d72ef4b85bda82f0fcd02ec721be19c1a6952791c8ee8",
+    "iso_checksum_type": "sha256",
+    "iso_name": "ubuntu-18.04.1-server-amd64.iso",
+    "memory": "4096",
+    "mirror": "http://cdimage.ubuntu.com/",
+    "mirror_directory": "ubuntu/releases/18.04.1/release",
+    "name": "ubuntu-18.04.1",
+    "preseed_path": "preseed.cfg",
+    "template": "ubuntu-18.04.1-amd64",
+    "version": "TIMESTAMP",
+    "cloud_token": "{{ env `VAGRANTCLOUD_TOKEN` }}",
+    "BUILD_ID": "{{ env `BUILD_ID` }}",
+    "NAME_PREFIX": "{{ env `NAME_PREFIX` }}",
+    "NAME_SUFFIX": "{{ env `NAME_SUFFIX` }}",
+    "CILIUM_BRANCH": "{{ env `CILIUM_BRANCH` }}"
+  },
+  "builders": [
+    {
+      "boot_command": [
+        "<esc><wait>",
+        "<esc><wait>",
+        "<enter><wait>",
+        "/install/vmlinuz<wait>",
+        " auto<wait>",
+        " console-setup/ask_detect=false<wait>",
+        " console-setup/layoutcode=us<wait>",
+        " console-setup/modelcode=pc105<wait>",
+        " debconf/frontend=noninteractive<wait>",
+        " debian-installer=en_US<wait>",
+        " fb=false<wait>",
+        " initrd=/install/initrd.gz<wait>",
+        " kbd-chooser/method=us<wait>",
+        " keyboard-configuration/layout=USA<wait>",
+        " keyboard-configuration/variant=USA<wait>",
+        " locale=en_US<wait>",
+        " netcfg/get_domain=vm<wait>",
+        " netcfg/get_hostname=vagrant<wait>",
+        " grub-installer/bootdev=/dev/sda<wait>",
+        " noapic<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}}<wait>",
+        " -- <wait>",
+        "<enter><wait>"
+      ],
+      "boot_wait": "10s",
+      "disk_size": "{{user `disk_size`}}",
+      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_os_type": "Ubuntu_64",
+      "hard_drive_interface": "sata",
+      "headless": "{{ user `headless` }}",
+      "http_directory": "http",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-virtualbox",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_pty": true,
+      "ssh_wait_timeout": "10000s",
+      "type": "virtualbox-iso",
+      "vboxmanage": [
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "{{ user `memory` }}"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "{{ user `cpus` }}"
+        ]
+      ],
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "{{ user `template` }}-{{ user `BUILD_ID` }}"
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
+      "expect_disconnect": true,
+      "scripts": [
+          "provision/ubuntu/kernel-next.sh"
+      ]
+    },{
+      "type": "file",
+      "source": "provision/env.bash",
+      "destination": "/tmp/env.bash"
+    },{
+      "type": "shell",
+      "environment_vars": [
+        "ENV_FILEPATH=/tmp/env.bash",
+        "IPROUTE_BRANCH=net-next"
+      ],
+      "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
+      "expect_disconnect": true,
+      "scripts": [
+          "provision/vagrant.sh",
+          "provision/ubuntu/install.sh",
+          "provision/golang.sh",
+          "provision/swap.sh",
+          "provision/registry.sh",
+          "provision/envoy.sh",
+          "provision/pull-images.sh"
+      ]
+    }
+  ],
+  "post-processors": [
+    [{
+      "output": "cilium-ginkgo-ubuntu-next-{{user `BUILD_ID`}}.box",
+      "type": "vagrant",
+      "compression_level": 9,
+      "keep_input_artifact": false
+    }, {
+      "type": "shell-local",
+      "inline": [
+        "/usr/local/bin/aws s3 cp cilium-ginkgo-ubuntu-next-{{user `BUILD_ID`}}.box s3://ciliumvagrantbaseboxes/"
+      ]
+    }],[{
+      "output": "cilium-ginkgo-ubuntu-next-{{user `BUILD_ID`}}.box",
+      "type": "vagrant",
+      "compression_level": 9,
+      "keep_input_artifact": false
+    },{
+      "type": "vagrant-cloud",
+      "box_tag": "cilium/ubuntu-next",
+      "access_token": "{{user `cloud_token`}}",
+      "version": "{{ user `BUILD_ID` }}",
+      "box_download_url": "https://s3-us-west-2.amazonaws.com/ciliumvagrantbaseboxes/cilium-ginkgo-ubuntu-next-{{user `BUILD_ID`}}.box"
+    }]
+
+  ]
+}

--- a/provision/ubuntu/install.sh
+++ b/provision/ubuntu/install.sh
@@ -3,22 +3,28 @@
 set -eu
 
 source "${ENV_FILEPATH}"
+export 'IPROUTE_BRANCH'=${IPROUTE_BRANCH:-"v4.14.0"}
 
 CLANG_DIR="clang+llvm-3.8.1-x86_64-linux-gnu-ubuntu-16.04"
 CLANG_FILE="${CLANG_DIR}.tar.xz"
 CLANG_URL="http://releases.llvm.org/3.8.1/${CLANG_FILE}"
 
-#If VBOX server
-VER="`cat /home/vagrant/.vbox_version`";
-ISO="VBoxGuestAdditions_$VER.iso";
-mkdir -p /tmp/vbox;
-mount -o loop ${HOME_DIR}/$ISO /tmp/vbox;
-sh /tmp/vbox/VBoxLinuxAdditions.run \
-    || echo "VBoxLinuxAdditions.run exited $? and is suppressed." \
-    "For more read https://www.virtualbox.org/ticket/12479";
-umount /tmp/vbox;
-rm -rf /tmp/vbox;
-rm -f ${HOME_DIR}/*.iso;
+# Newest kernels already have the vbox modules into that. GuestAdditions are no
+# longer needed.
+VBOXSF=$(sudo lsmod | grep vboxsf | wc -l)
+if [[ "${VBOXSF}" -eq 0 ]]; then
+    VER="`cat /home/vagrant/.vbox_version`";
+    ISO="VBoxGuestAdditions_$VER.iso";
+    mkdir -p /tmp/vbox;
+    mount -o loop ${HOME_DIR}/$ISO /tmp/vbox;
+    sh /tmp/vbox/VBoxLinuxAdditions.run \
+        || echo "VBoxLinuxAdditions.run exited $? and is suppressed." \
+        "For more read https://www.virtualbox.org/ticket/12479";
+    umount /tmp/vbox;
+    rm -rf /tmp/vbox;
+    rm -f ${HOME_DIR}/*.iso;
+fi
+
 
 echo "Provision a new server"
 sudo apt-get update
@@ -62,7 +68,7 @@ pip install yamllint
 
 #IP Route
 cd /tmp
-git clone -b v4.14.0 git://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git
+git clone -b ${IPROUTE_BRANCH} git://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git
 cd /tmp/iproute2
 ./configure
 make -j `getconf _NPROCESSORS_ONLN`

--- a/provision/ubuntu/kernel-next.sh
+++ b/provision/ubuntu/kernel-next.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -xe
+
+export 'IPROUTE_BRANCH'=${IPROUTE_BRANCH:-"net-next"}
+export 'KCONFIG'=${KCONFIG:-"config-`uname -r`"}
+
+
+sudo apt-get install -y --allow-downgrades \
+    pkg-config bison flex build-essential gcc libssl-dev \
+    libelf-dev bc
+
+git clone --depth 1 git://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git $HOME/k
+cd $HOME/k
+
+# This patches fixes some issues with Vboxguest/VboxSF. Need to be removed when are merged.
+# curl https://patchwork.kernel.org/patch/10216607/raw/ -o vboxfs_patch
+# git apply  vboxfs_patch
+
+# curl https://patchwork.kernel.org/patch/10315021/raw/ -o vguest_patch_1
+# curl https://patchwork.kernel.org/patch/10315017/raw/ -o vguest_patch_2
+
+# git apply vguest_patch_1
+# git apply vguest_patch_2
+
+cp /boot/config-`uname -r` .config
+make oldconfig && make prepare
+
+./scripts/config --module CONFIG_VBOXSF_FS
+./scripts/config --module CONFIG_VBOXGUEST
+./scripts/config --disable CONFIG_DEBUG_INFO
+./scripts/config --disable CONFIG_DEBUG_KERNEL
+./scripts/config --enable CONFIG_BPF
+./scripts/config --enable CONFIG_BPF_SYSCALL
+./scripts/config --module CONFIG_NETFILTER_XT_MATCH_BPF
+./scripts/config --module CONFIG_NET_CLS_BPF
+./scripts/config --module CONFIG_NET_ACT_BPF
+./scripts/config --enable CONFIG_BPF_JIT
+./scripts/config --enable CONFIG_HAVE_BPF_JIT
+./scripts/config --enable CONFIG_BPF_EVENTS
+./scripts/config --enable BPF_STREAM_PARSER
+./scripts/config --module CONFIG_TEST_BPF
+./scripts/config --disable CONFIG_LUSTRE_FS
+./scripts/config --enable CONFIG_CGROUP_BPF
+./scripts/config --module CONFIG_NET_SCH_INGRESS
+./scripts/config --enable CONFIG_NET_CLS_ACT
+./scripts/config --enable CONFIG_LWTUNNEL_BPF
+./scripts/config --enable CONFIG_HAVE_EBPF_JIT
+./scripts/config --module CONFIG_NETDEVSIM
+
+
+sudo make deb-pkg
+cd ..
+sudo dpkg -i linux-*.deb


### PR DESCRIPTION
This is a new feature request.

This commit added support to create a new Ubuntu Virtualbox image to
upload it to `cilium/ubuntu-next` with the latest changes from the
kernel.

This commit consist in the following changes:

- Jenkinsfile-next to build ubuntu-next from other jobs.
- Makefile: Added distribution ubuntu-next
- kernel-next: To install a new kernel from net-next. ATM is applying a
patch that are not already merged in kernel.
- ubuntu/install: Add iproute from net-next (if specified) and the skip
vboxsf installation if is already present.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>