### PR TITLE
Ubuntu: Installed moreutils package

### DIFF
--- a/provision/ubuntu/install.sh
+++ b/provision/ubuntu/install.sh
@@ -41,7 +41,7 @@ sudo apt-get install -y --allow-downgrades \
     python-sphinx python-pip \
     libncurses5-dev libslang2-dev gettext \
     libselinux1-dev debhelper lsb-release \
-    po-debconf autoconf autopoint
+    po-debconf autoconf autopoint moreutils
 
 # Install nsenter for kubernetes
 cd /tmp


### PR DESCRIPTION
This package allow use to run monitor with timestamps

```
vagrant@runtime1:~/go/src/github.com/cilium/cilium$ cilium monitor | ts '[%Y-%m-%d %H:%M:%S]'
[2018-04-03 17:34:26] Listening for events on 2 CPUs with 64x4096 of shared memory
[2018-04-03 17:34:26] Press Ctrl-C to quit
[2018-04-03 17:35:11] >> Endpoint regenerated: 29898 (reserved:health)
[2018-04-03 17:35:11] >> Endpoint regenerated: 38939 (container:id.httpd)
[2018-04-03 17:35:11] >> Endpoint regenerated: 173 (container:id.client)
[2018-04-03 17:35:11] >> Endpoint regenerated: 56326 (container:id.server)
```

Related to: https://github.com/cilium/cilium/issues/3233

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>