### PR TITLE
ubuntu: Use pip from packages

### DIFF
--- a/provision/ubuntu/install.sh
+++ b/provision/ubuntu/install.sh
@@ -56,7 +56,6 @@ cd ..
 rm -fr util-linux-2.30.1/ util-linux-2.30.1.tar.gz
 
 # Documentation dependencies
-pip install --upgrade pip
 pip install sphinx sphinxcontrib-httpdomain sphinxcontrib-openapi sphinx-rtd-theme sphinx-tabs recommonmark
 pip install yamllint
 


### PR DESCRIPTION
Upgrading pip by itself to version 10.0 results in errors.[0]

[0] https://github.com/pypa/pip/issues/5240

Signed-off-by: Michal Rostecki <mrostecki@suse.com>