### PR TITLE
Pull istio images in packer-ci-build

### DIFF
--- a/provision/pull-images.sh
+++ b/provision/pull-images.sh
@@ -9,6 +9,8 @@ for img in tgraf/netperf httpd cilium/demo-httpd \
   registry busybox:latest quay.io/coreos/etcd:v3.1.0 \
   digitalwonderland/zookeeper wurstmeister/kafka \
   cilium/kafkaclient2 cilium/starwars \
+  istio/examples-bookinfo-reviews-v1 istio/examples-bookinfo-productpage-v1 \
+  istio/examples-bookinfo-details-v1 istio/examples-bookinfo-reviews-v2:0.2.8 \
   cilium/cilium:v1.0.0; do
   sudo docker pull $img &
 done


### PR DESCRIPTION
Had seen in the Jenkins that some images are not ready after timeout.
This make things a bit faster

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>