### PR TITLE
envoy: Use Bazel version of the cloned Cilium branch.

### DIFF
--- a/provision/env.bash
+++ b/provision/env.bash
@@ -3,7 +3,6 @@
 export GOLANG_VERSION="1.9.3"
 export ETCD_VERSION="v3.1.0"
 export DOCKER_COMPOSE_VERSION="1.16.1"
-export BAZEL_VERSION="0.11.0"
 export CONTAINERD_VERSION="1.1.0"
 export CLANG_ROOT=/usr/local/clang
 export HOME_DIR=/home/vagrant

--- a/provision/envoy.sh
+++ b/provision/envoy.sh
@@ -13,8 +13,19 @@ sudo -u vagrant -E sh -c "\
     cd \"${GOPATH}/src/github.com/cilium\" && \
     git clone -b ${CILIUM_BRANCH} https://github.com/cilium/cilium.git && \
     cd cilium && \
-    git submodule update --init --recursive && \
-    cd envoy && \
+    git submodule update --init --recursive"
+
+export BAZEL_VERSION=`cat "${GOPATH}/src/github.com/cilium/cilium/envoy/BAZEL_VERSION"`
+
+# Install bazel
+wget -nv "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"
+chmod +x "bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"
+sudo -E "./bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"
+sudo -E mv /usr/local/bin/bazel /usr/bin
+rm "bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"
+
+sudo -u vagrant -E sh -c "\
+    cd \"${GOPATH}/src/github.com/cilium/cilium/envoy\" && \
     grep \"ENVOY_SHA[ \t]*=\" WORKSPACE | cut -d \\\" -f 2 >SOURCE_VERSION && \
     cat SOURCE_VERSION && \
     make && \

--- a/provision/ubuntu/install.sh
+++ b/provision/ubuntu/install.sh
@@ -160,13 +160,5 @@ EOF
 sudo systemctl disable apport.service
 sudo sh -c 'echo "sysctl kernel.core_pattern=/tmp/core.%e.%p.%t" > /etc/sysctl.d/66-core-pattern.conf'
 
-# Install bazel
-wget -nv "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"
-chmod +x "bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"
-sudo -E "./bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"
-sudo -E mv /usr/local/bin/bazel /usr/bin
-rm "bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"
-
-
 # Kernel parameters
 sudo sh -c 'echo "kernel.randomize_va_space=0" > /etc/sysctl.d/67-randomize_va_space.conf'


### PR DESCRIPTION
The cloned Cilium branch contains 'envoy/BAZEL_VERSION' file that
specified which version of Bazel to install. Use it so that we do not
need to keep updating the packer-ci-build repo every time Bazel
version is bumped.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>