### PR TITLE
ubuntu: Bump journald log ratelimit to 10000

### DIFF
--- a/provision/ubuntu/install.sh
+++ b/provision/ubuntu/install.sh
@@ -162,7 +162,7 @@ sudo sh -c 'echo "sysctl kernel.core_pattern=/tmp/core.%e.%p.%t" > /etc/sysctl.d
 
 # journald configuration
 sudo bash -c "echo RateLimitIntervalSec=1s >> /etc/systemd/journald.conf"
-sudo bash -c "echo RateLimitBurst=1000 >> /etc/systemd/journald.conf"
+sudo bash -c "echo RateLimitBurst=10000 >> /etc/systemd/journald.conf"
 sudo systemctl restart systemd-journald
 
 # Kernel parameters


### PR DESCRIPTION
In common test environments, it is easy for LDS + NPDS configuration for
~10 endpoints to generate more than 1000 lines of log messages within a
second. To prevent losing logs in test environments, bump this ratelimit
to 10000.