### PR TITLE
Disable swappiness

### DIFF
--- a/provision/swap.sh
+++ b/provision/swap.sh
@@ -2,3 +2,5 @@
 
 # Disable swap filesystem by default. Needed by kubernetes >1.7
 sudo sed -i.bak '/ swap / s/^\(.*\)$/#\1/g' /etc/fstab
+
+sudo sh -c 'echo "sysctl vm.swappiness=0" > /etc/sysctl.d/60-swappiness.conf'


### PR DESCRIPTION
Found a PR triage that the CPU was used by Kswapd, so disable it just to
make sure that it's not user until is needed.

Doc:
https://askubuntu.com/questions/259739/kswapd0-is-taking-a-lot-of-cpu

```
38 root      20   0       0      0      0 S  18.8  0.0   3:17.73 kswapd0
```

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>