### PR TITLE
Install ninja-build on Ubuntu, now required to build Envoy

### DIFF
--- a/provision/ubuntu/install.sh
+++ b/provision/ubuntu/install.sh
@@ -42,7 +42,7 @@ sudo apt-get install -y --allow-downgrades \
     libncurses5-dev libslang2-dev gettext \
     libselinux1-dev debhelper lsb-release \
     po-debconf autoconf autopoint moreutils \
-    libseccomp2 libenchant1c2a
+    libseccomp2 libenchant1c2a ninja-build
 
 # Install nsenter for kubernetes
 cd /tmp


### PR DESCRIPTION
Cf. the updated dependencies for building Istio 1.0.0 istio-proxy: https://github.com/envoyproxy/envoy/blob/master/bazel/README.md#quick-start-bazel-build-for-developers

Signed-off-by: Romain Lenglet <romain@covalent.io>