### PR TITLE
Install Golang dependencies as vagrant user.

### DIFF
--- a/provision/golang.sh
+++ b/provision/golang.sh
@@ -4,14 +4,14 @@ source "${ENV_FILEPATH}"
 
 set -e
 
-sudo -E mkdir "${GOPATH}" && \
+sudo -u vagrant -E bash -c "mkdir ${GOPATH} && \
 go get -u github.com/cilium/go-bindata/... && \
 go get -u github.com/google/gops && \
 go get -u github.com/golang/protobuf/protoc-gen-go && \
 go get -u github.com/lyft/protoc-gen-validate && \
 go get github.com/subfuzion/envtpl && \
 go get github.com/ksonnet/kubecfg && \
-go get -u github.com/gordonklaus/ineffassign
+go get -u github.com/gordonklaus/ineffassign"
 
 #Protoc-gen-validate installation
 cd $GOPATH/src/github.com/lyft/protoc-gen-validate


### PR DESCRIPTION
At the moment the Golang dependencies are created by root user, this
means that the CI system will complain because `~/.cache/go-build`, this
commit install all golang programs as vagrant user.

Fix https://github.com/cilium/cilium/issues/5059

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>