### PR TITLE
provision: Pull in new cilium-init container image

### DIFF
--- a/provision/pull-images.sh
+++ b/provision/pull-images.sh
@@ -16,6 +16,7 @@ if [ -z "${NAME_PREFIX}" ]; then
         docker.io/cilium/cilium:v1.0.6 \
         docker.io/cilium/cilium:v1.1.5 \
         docker.io/cilium/cilium:v1.2.4 \
+        docker.io/cilium/cilium-init:2018-10-16 \
         docker.io/cilium/connectivity-container:v1.0 \
         docker.io/cilium/demo-client:latest \
         docker.io/cilium/demo-httpd:latest \


### PR DESCRIPTION
Pull in the cilium-init image from https://github.com/cilium/cilium/pull/5857 .