### PR TITLE
Ubuntu Next: Fix aws path

### DIFF
--- a/cilium-ubuntu-next.json
+++ b/cilium-ubuntu-next.json
@@ -124,7 +124,7 @@
     }, {
       "type": "shell-local",
       "inline": [
-        "/usr/local/bin/aws s3 cp cilium-ginkgo-ubuntu-next-{{user `BUILD_ID`}}.box s3://ciliumvagrantbaseboxes/"
+        "/usr/bin/aws s3 cp cilium-ginkgo-ubuntu-next-{{user `BUILD_ID`}}.box s3://ciliumvagrantbaseboxes/"
       ]
     }],[{
       "output": "cilium-ginkgo-ubuntu-next-{{user `BUILD_ID`}}.box",


### PR DESCRIPTION
Aws failed in the first build for aws path

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

Logs from ubuntu-next-build: 
https://jenkins.cilium.io/job/Vagrant-Master-Boxes-Packer-Build-net-next/1/console
```
12:17:20 [0;32m    virtualbox-iso (shell-local): /tmp/packer-shell144633189: 2: /tmp/packer-shell144633189: /usr/local/bin/aws: not found[0m
12:17:20 [1;32m==> virtualbox-iso: Running post-processor: vagrant[0m
12:17:20 [1;32m==> virtualbox-iso (vagrant): Creating Vagrant box for 'virtualbox' provider[0m
```