### PR TITLE
Test: Fix vbox additions on net-next kernel

### DIFF
--- a/cilium-ubuntu-next.json
+++ b/cilium-ubuntu-next.json
@@ -100,7 +100,8 @@
       "type": "shell",
       "environment_vars": [
         "ENV_FILEPATH=/tmp/env.bash",
-        "IPROUTE_BRANCH=net-next"
+        "IPROUTE_BRANCH=net-next",
+        "GUESTADDITIONS=false"
       ],
       "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
       "expect_disconnect": true,

--- a/provision/ubuntu/install.sh
+++ b/provision/ubuntu/install.sh
@@ -4,15 +4,13 @@ set -eu
 
 source "${ENV_FILEPATH}"
 export 'IPROUTE_BRANCH'=${IPROUTE_BRANCH:-"v4.14.0"}
+export GUESTADDITIONS=${GUESTADDITIONS:-"true"}
 
 CLANG_DIR="clang+llvm-3.8.1-x86_64-linux-gnu-ubuntu-16.04"
 CLANG_FILE="${CLANG_DIR}.tar.xz"
 CLANG_URL="http://releases.llvm.org/3.8.1/${CLANG_FILE}"
 
-# Newest kernels already have the vbox modules into that. GuestAdditions are no
-# longer needed.
-VBOXSF=$(sudo lsmod | grep vboxsf | wc -l)
-if [[ "${VBOXSF}" -eq 0 ]]; then
+if [[ "${GUESTADDITIONS}" == "true" ]]; then
     VER="`cat /home/vagrant/.vbox_version`";
     ISO="VBoxGuestAdditions_$VER.iso";
     mkdir -p /tmp/vbox;


### PR DESCRIPTION
When a new kernel is in place the vboxsf is only used when a shared
folder is in used, and that does not happens during the packer-ci-build.

With this change we validate that the kernel is greater than 1.17 where
vbox modules are already in there.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>