### PR TITLE
Net-Next kernel fix shared folders

### DIFF
--- a/provision/ubuntu/kernel-next.sh
+++ b/provision/ubuntu/kernel-next.sh
@@ -52,3 +52,5 @@ make oldconfig && make prepare
 sudo make deb-pkg
 cd ..
 sudo dpkg -i linux-*.deb
+
+sudo reboot


### PR DESCRIPTION
On net-next kernel the reboot was not in place, so when VboxAdditions is
installed is not correctly installed due is using the old kernel, so it
fails on vagrant import due no vboxsf module.

With this change, after install the net-next kernel a reboot is made to
start with the latest kernel.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>