### PR TITLE
cilium: packer ci builds include kTLS support

### DIFF
--- a/provision/ubuntu/kernel-next.sh
+++ b/provision/ubuntu/kernel-next.sh
@@ -47,6 +47,7 @@ make oldconfig && make prepare
 ./scripts/config --enable CONFIG_LWTUNNEL_BPF
 ./scripts/config --enable CONFIG_HAVE_EBPF_JIT
 ./scripts/config --module CONFIG_NETDEVSIM
+./scripts/config --module CONFIG_TLS
 
 
 sudo make deb-pkg


### PR DESCRIPTION
Net-next kernels support kTLS in order to test we need to add the CONFIG_TLS module support.

Signed-off-by: John Fastabend <john.fastabend@gmail.com>