### PR TITLE
provision: pull Spotify Kafka proxy image

### DIFF
--- a/provision/pull-images.sh
+++ b/provision/pull-images.sh
@@ -42,6 +42,7 @@ if [ -z "${NAME_PREFIX}" ]; then
         docker.io/wurstmeister/kafka:1.1.0 \
         docker.io/nebril/python-binary-memcached \
         docker.io/memcached:1.5.11 \
+        docker.io/spotify/kafkaproxy:latest \
         gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.10 \
         gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.10 \
         gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.10 \


### PR DESCRIPTION
Recent Cilium builds have been failing due to containers getting stuck in `ContainerCreating` state during the Kafka tests, specifically the Kafka broker. While this is because of network issues on the CI side (unrelated to Cilium), downloading this image should reduce the time the tests take, as well as insulate the CI against intermittent networking problems that are not in our control on the baremetal machines used in CI. 

Related Cilium issue: https://github.com/cilium/cilium/issues/6303

Signed-off by: Ian Vernon <ian@cilium.io>
