### PR TITLE
provision: fix permissions for packages installed via pip3

### DIFF
--- a/provision/ubuntu/install.sh
+++ b/provision/ubuntu/install.sh
@@ -152,7 +152,12 @@ sudo systemctl enable etcd
 sudo systemctl start etcd
 
 sudo -u vagrant -E sh -c 'echo "export PATH='${PATH}':${HOME_DIR}/.local/bin" >> "${HOME_DIR}/.bashrc"'
-echo "export PATH=${PATH}:/root/.local/bin" >> "/root/.bashrc"
+
+# Packages installed by vagrant user via pip3 are installed in its home directory.
+echo "export PATH=${PATH}:/home/vagrant/.local/bin" >> "/root/.bashrc"
+
+# Allow vagrant user to access newly installed Python packages.
+chown -R "vagrant:vagrant" ${HOME_DIR}/.local
 
 # Clean all downloaded packages
 sudo apt-get -y clean


### PR DESCRIPTION
When running the latest version of the VM (127), yamllint is not in the path of
the vagrant user:

```
vagrant@runtime:~$ which yamllint
vagrant@runtime:~
```

This is because it is in `~/.local` directory, which the vagrant user cannot
access:

```
vagrant@runtime:~$ ls .local
ls: cannot open directory '.local': Permission denied
```

The permissions assigned to it reveal this:
```
vagrant@runtime:~$ ls -altr
total 60
...
drwx------ 4 root    root    4096 Jan 29 23:20 .local
...
```

This is fixed by changing the permissions on the directory to allow the vagrant
user to access it:

```
vagrant@runtime:~$ sudo chown -R "vagrant:vagrant" ~/.local
vagrant@runtime:~$ which yamllint
/home/vagrant/.local/bin/yamllint
```

Set the correct permissions in the install.sh script. Also fix the path for the
root user to point to the vagrant user's `.local` directory as that is where
pip3 installs packages / dependencies.

Fixes: b6cf3cc ("install python3-sphinx and add ~/.local/bin to PATH")

Signed-off by: Ian Vernon <ian@cilium.io>