### PR TITLE
ubuntu-next: Get rid of box_basename

### DIFF
--- a/cilium-opensuse.json
+++ b/cilium-opensuse.json
@@ -1,6 +1,5 @@
 {
   "variables": {
-    "box_basename": "opensuse-tumbleweed",
     "cpus": "8",
     "disk_size": "40960",
     "headless": "true",

--- a/cilium-ubuntu-next.json
+++ b/cilium-ubuntu-next.json
@@ -1,7 +1,6 @@
 {
 
   "variables": {
-    "box_basename": "ubuntu-18.10",
     "cpus": "8",
     "disk_size": "40960",
     "headless": "true",

--- a/cilium-ubuntu.json
+++ b/cilium-ubuntu.json
@@ -1,6 +1,5 @@
 {
   "variables": {
-    "box_basename": "ubuntu-18.10",
     "cpus": "8",
     "disk_size": "40960",
     "headless": "true",


### PR DESCRIPTION
Fixes a small nit (creating this PR to trigger build of `ubuntu-next`).
