### PR TITLE
opensuse: Switch to Tumbleweed release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 DISTRIBUTION ?= ubuntu
 JQ ?= del(."post-processors"[])
+PACKER ?= packer
 
 ifeq ($(DISTRIBUTION), ubuntu)
 JSON_FILE = cilium-ubuntu.json
@@ -17,10 +18,10 @@ endif
 all: build
 
 build: clean fetch-opensuse-ovf validate
-	jq '$(JQ)' $(JSON_FILE) | packer build $(ARGS) -
+	jq '$(JQ)' $(JSON_FILE) | $(PACKER) build $(ARGS) -
 
 validate:
-	jq '$(JQ)' $(JSON_FILE) | packer validate -
+	jq '$(JQ)' $(JSON_FILE) | $(PACKER) validate -
 
 clean:
 	rm -Rf $(BOX_FILE) tmp packer_cache packer-*

--- a/provision/opensuse/install.sh
+++ b/provision/opensuse/install.sh
@@ -4,9 +4,7 @@ set -eux
 
 source "${ENV_FILEPATH}"
 
-zypper ar -r https://download.opensuse.org/repositories/devel:/CaaSP:/Head:/ControllerNode/openSUSE_Leap_15.0/devel:CaaSP:Head:ControllerNode.repo
-zypper ar -r https://download.opensuse.org/repositories/devel:/kubic/openSUSE_Leap_15.0/devel:kubic.repo
-zypper ar -r https://download.opensuse.org/repositories/devel:/languages:/go/openSUSE_Leap_15.0/devel:languages:go.repo
+zypper ar -r https://download.opensuse.org/repositories/devel:/kubic/openSUSE_Tumbleweed/devel:kubic.repo
 zypper -n --gpg-auto-import-key in --no-recommends \
         autoconf \
         automake \

--- a/tools/download-opensuse-ovf.sh
+++ b/tools/download-opensuse-ovf.sh
@@ -7,10 +7,10 @@ set -eux
 # in their content. This script downloads openSUSE Vagrant box and extracts
 # OVF/OVA from it.
 
-OPENSUSE_VERSION="15.0"
+OPENSUSE_VERSION="Tumbleweed"
 ARCH="x86_64"
 BOX_VERSION="1.0.6.20181025"
-SHA256SUM="3f460c590c514d95a7ad3f83ea288374a214d3102674abaa2027dfe21af368c9"
+SHA256SUM="a60567af6e12e203e14d5882e14347e262b14dea2cc276bafefd7cb955033fec"
 
 BOX_FILENAME="virtualbox-${BOX_VERSION}.box"
 BOX_CONTENT_DIR="opensuse_base_box"


### PR DESCRIPTION
The devel:kubic repository has no intention of being usable on stable
releases of openSUSE and packages needed for Cilium development are too
fresh to be included in stable releases. The rolling-release version
(Tumbleweed) needs to be used.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>