### PR TITLE
ubuntu-next: More vboxsf fixes

### DIFF
--- a/cilium-ubuntu-next.json
+++ b/cilium-ubuntu-next.json
@@ -105,13 +105,13 @@
       "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
       "expect_disconnect": true,
       "scripts": [
-          "provision/ubuntu/vboxsf-next.sh",
           "provision/vagrant.sh",
           "provision/ubuntu/install.sh",
           "provision/golang.sh",
           "provision/swap.sh",
           "provision/registry.sh",
-          "provision/pull-images.sh"
+          "provision/pull-images.sh",
+          "provision/ubuntu/vboxsf-next.sh"
       ]
     }
   ],


### PR DESCRIPTION
Prevents from overwritting the manually compiled `vboxsf.ko`.