### PR TITLE
ubuntu-next: Fix vboxsf on 18.04.2

### DIFF
--- a/cilium-ubuntu-next.json
+++ b/cilium-ubuntu-next.json
@@ -105,9 +105,9 @@
       "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
       "expect_disconnect": true,
       "scripts": [
-          "provision/ubuntu/vboxsf-next.sh",
           "provision/vagrant.sh",
           "provision/ubuntu/install.sh",
+          "provision/ubuntu/vboxsf-next.sh",
           "provision/golang.sh",
           "provision/swap.sh",
           "provision/registry.sh",

--- a/provision/ubuntu/kernel-next.sh
+++ b/provision/ubuntu/kernel-next.sh
@@ -5,7 +5,6 @@ set -xe
 export 'IPROUTE_BRANCH'=${IPROUTE_BRANCH:-"net-next"}
 export 'KCONFIG'=${KCONFIG:-"config-`uname -r`"}
 
-
 sudo apt-get install -y --allow-downgrades \
     pkg-config bison flex build-essential gcc libssl-dev \
     libelf-dev bc
@@ -39,7 +38,7 @@ make oldconfig && make prepare
 ./scripts/config --module CONFIG_TLS
 
 
-sudo make deb-pkg
+sudo make -j$(nproc) deb-pkg
 cd ..
 sudo dpkg -i linux-*.deb
 sudo ln -sf /boot/System.map-$(uname -r) /boot/System.map


### PR DESCRIPTION
This PR:

- Fixes (again) vboxsf on 18.04.2.
- Changes the order of installation of the vboxsf module installation to prevent from being overwritten by the guest additions.
- Enables parallelism for compiling the kernel.