### PR TITLE
ubuntu-next: Do not set IPROUTE_BRANCH

### DIFF
--- a/cilium-ubuntu-next.json
+++ b/cilium-ubuntu-next.json
@@ -99,7 +99,6 @@
       "type": "shell",
       "environment_vars": [
         "ENV_FILEPATH=/tmp/env.bash",
-        "IPROUTE_BRANCH=net-next",
         "GUESTADDITIONS=https://download.virtualbox.org/virtualbox/5.2.20/VBoxGuestAdditions_5.2.20.iso"
       ],
       "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'",

--- a/provision/ubuntu/kernel-next.sh
+++ b/provision/ubuntu/kernel-next.sh
@@ -2,7 +2,6 @@
 
 set -xe
 
-export 'IPROUTE_BRANCH'=${IPROUTE_BRANCH:-"net-next"}
 export 'KCONFIG'=${KCONFIG:-"config-`uname -r`"}
 
 sudo apt-get install -y --allow-downgrades \


### PR DESCRIPTION
It is being set in `provision/ubuntu/install.sh`.

Fixes: 6c6477ca3 ("provision: Pull in custom iproute2 changes")