### PR TITLE
ubuntu-next: remove obsolete mount.vboxsf binary

### DIFF
--- a/provision/ubuntu/vboxsf-next.sh
+++ b/provision/ubuntu/vboxsf-next.sh
@@ -12,3 +12,4 @@ git checkout fb360320b7d5c2dc74cb958c9b27e8708c1c9bc2
 make
 sudo make modules_install
 sudo depmod -a
+sudo rm $(which mount.vboxsf)


### PR DESCRIPTION
Otherwise, vboxsf complains when mounting:

```
vboxsf: Old binary mount data not supported, remove obsolete mount.vboxsf and/or update your VBoxService.
```

Signed-off-by: Martynas Pumputis <m@lambda.lt>