### PR TITLE
Temporarily disable opensuse build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,13 +26,13 @@ pipeline {
     }
 
     stages {
-        stage('OpenSuse') {
-            steps {
-                sh 'git submodule update --init --recursive'
-                sh 'make clean DISTRIBUTION=opensuse'
-                sh 'make build DISTRIBUTION=opensuse'
-            }
-        }
+        //stage('OpenSuse') {
+        //    steps {
+        //        sh 'git submodule update --init --recursive'
+        //        sh 'make clean DISTRIBUTION=opensuse'
+        //        sh 'make build DISTRIBUTION=opensuse'
+        //    }
+        //}
         stage('Ubuntu') {
             steps {
                 sh 'echo "${JQ}"'


### PR DESCRIPTION
OpenSUSE Tumbleweed is currently broken, leading to master build errors like this:

https://jenkins.cilium.io/job/Vagrant-Master-Boxes-Packer-Build/135/execution/node/26/log/
```
15:58:16     virtualbox-ovf: Resolving package dependencies...
15:58:16     virtualbox-ovf: 5 Problems:
15:58:16     virtualbox-ovf: Problem: iproute2-cilium-4.20-187.1.x86_64 requires libm.so.6(GLIBC_2.29)(64bit), but this requirement cannot be provided
15:58:16     virtualbox-ovf: Problem: cri-o-1.13.0-2.8.x86_64 requires libostree-1.so.1()(64bit), but this requirement cannot be provided
15:58:16     virtualbox-ovf: Problem: docker-18.09.1_ce-1.1.x86_64 requires iproute2 >= 3.5, but this requirement cannot be provided
15:58:16     virtualbox-ovf: Problem: python3-docker-compose-1.23.2-2.2.noarch requires python(abi) = 3.7, but this requirement cannot be provided
15:58:16     virtualbox-ovf: Problem: git-2.20.1-3.2.x86_64 requires git-core = 2.20.1, but this requirement cannot be provided
```

Disable OpenSUSE builds temporarily. This can be reverted when Tumbleweed stabilises.