### PR TITLE
Fix iproute2 image pull

### DIFF
--- a/provision/pull-images.sh
+++ b/provision/pull-images.sh
@@ -59,7 +59,7 @@ if [ -z "${NAME_PREFIX}" ]; then
         gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.10 \
         gcr.io/google_samples/gb-redisslave:v1 \
         quay.io/cilium/cilium-builder:2019-02-19 \
-        quay.io/cilium/cilium-runtime:2019-02-19 \
+        quay.io/cilium/cilium-runtime:2019-02-20 \
         quay.io/coreos/etcd:v3.3.9 \
         quay.io/coreos/hyperkube:v1.7.6_coreos.0; \
     do

--- a/provision/ubuntu/install.sh
+++ b/provision/ubuntu/install.sh
@@ -3,7 +3,7 @@
 set -eu
 
 source "${ENV_FILEPATH}"
-export 'IPROUTE_BRANCH'=${IPROUTE_BRANCH:-"4.20.0-1ubuntu0bjn2"}
+export 'IPROUTE_BRANCH'=${IPROUTE_BRANCH:-"static-data"}
 export 'IPROUTE_GIT'=${IPROUTE_GIT:-https://github.com/cilium/iproute2}
 export 'GUESTADDITIONS'=${GUESTADDITIONS:-""}
 


### PR DESCRIPTION
The version we pointed to only had the patches as files inside the repo,
not applied to the actual codebase. Fix it by pointing to a branch that
actually has the patches applied.