### PR TITLE
Fix building from a non-master branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
         AWS_ACCESS_KEY_ID = credentials('AWS_ACCESS_KEY_ID')
         AWS_SECRET_ACCESS_KEY = credentials('AWS_SECRET_ACCESS_KEY')
         AWS_DEFAULT_REGION = credentials('AWS_DEFAULT_REGION')
-        CILIUM_BRANCH = "${params.CiliumBranch}"
+        BRANCH = "${params.CiliumBranch}"
     }
 
     stages {

--- a/Jenkinsfile-next
+++ b/Jenkinsfile-next
@@ -20,6 +20,7 @@ pipeline {
         VAGRANTCLOUD_TOKEN = credentials('vagrantcloud token')
         AWS_ACCESS_KEY_ID = credentials('AWS_ACCESS_KEY_ID')
         AWS_SECRET_ACCESS_KEY = credentials('AWS_SECRET_ACCESS_KEY')
+        BRANCH = "${params.CiliumBranch}"
     }
 
     stages {

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 DISTRIBUTION ?= ubuntu
 JQ ?= del(."post-processors"[])
 PACKER ?= packer
+BRANCH ?= master
 
 ifeq ($(DISTRIBUTION), ubuntu)
 JSON_FILE = cilium-ubuntu.json
@@ -18,7 +19,9 @@ endif
 all: build
 
 build: clean fetch-opensuse-ovf validate
+	git checkout $(BRANCH)
 	jq '$(JQ)' $(JSON_FILE) | $(PACKER) build $(ARGS) -
+	git checkout -
 
 validate:
 	jq '$(JQ)' $(JSON_FILE) | $(PACKER) validate -


### PR DESCRIPTION
Previously, the build branch param was ignored.

This PR enables building VM images from a custom branch (e.g. `origin/foobar`).