### PR TITLE
OpenSUSE: Switch to standard cilium package

### DIFF
--- a/provision/opensuse/install.sh
+++ b/provision/opensuse/install.sh
@@ -5,10 +5,8 @@ set -eux
 source "${ENV_FILEPATH}"
 
 RELEASE="openSUSE_Tumbleweed"
-IPROUTE2_REPO="home:joestringer:branches:security:netfilter"
 
 zypper ar -r https://download.opensuse.org/repositories/devel:/kubic/${RELEASE}/devel:kubic.repo
-zypper ar -r https://download.opensuse.org/repositories/${IPROUTE2_REPO}/${RELEASE}/${IPROUTE2_REPO}.repo
 zypper -n --gpg-auto-import-key in --no-recommends \
         autoconf \
         automake \
@@ -25,7 +23,7 @@ zypper -n --gpg-auto-import-key in --no-recommends \
         etcd \
         git \
         "go${GOLANG_VERSION_MINOR}" \
-        iproute2-cilium -iproute2 \
+        iproute2 \
         jq \
         llvm \
     && zypper clean


### PR DESCRIPTION
Tumbleweed accepted the static data POC changes:
    
https://build.opensuse.org/request/show/682651
    
Switch to the upstream iproute2 now that we don't need to rely on my
personal OpenSUSE repository with the changes.