### PR TITLE
net-next: Apply BPF-related patches

### DIFF
--- a/cilium-ubuntu-next.json
+++ b/cilium-ubuntu-next.json
@@ -85,6 +85,10 @@
   ],
   "provisioners": [
     {
+      "type": "file",
+      "source": "net-next-patches/",
+      "destination": "/tmp/"
+    },{
       "type": "shell",
       "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
       "expect_disconnect": true,

--- a/net-next-patches/bpf-gso.patch
+++ b/net-next-patches/bpf-gso.patch
@@ -1,0 +1,78 @@
+From 4c3024debf62de4c6ac6d3cb4c0063be21d4f652 Mon Sep 17 00:00:00 2001
+From: Willem de Bruijn <willemb@google.com>
+Date: Wed, 6 Mar 2019 14:35:15 -0500
+Subject: bpf: only test gso type on gso packets
+
+BPF can adjust gso only for tcp bytestreams. Fail on other gso types.
+
+But only on gso packets. It does not touch this field if !gso_size.
+
+Fixes: b90efd225874 ("bpf: only adjust gso_size on bytestream protocols")
+Signed-off-by: Willem de Bruijn <willemb@google.com>
+Acked-by: Yonghong Song <yhs@fb.com>
+Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>
+---
+ include/linux/skbuff.h | 4 ++--
+ net/core/filter.c      | 8 ++++----
+ 2 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/include/linux/skbuff.h b/include/linux/skbuff.h
+index 27beb549ffbe..f32f32407dc4 100644
+--- a/include/linux/skbuff.h
++++ b/include/linux/skbuff.h
+@@ -4232,10 +4232,10 @@ static inline bool skb_is_gso_sctp(const struct sk_buff *skb)
+ 	return skb_shinfo(skb)->gso_type & SKB_GSO_SCTP;
+ }
+ 
++/* Note: Should be called only if skb_is_gso(skb) is true */
+ static inline bool skb_is_gso_tcp(const struct sk_buff *skb)
+ {
+-	return skb_is_gso(skb) &&
+-	       skb_shinfo(skb)->gso_type & (SKB_GSO_TCPV4 | SKB_GSO_TCPV6);
++	return skb_shinfo(skb)->gso_type & (SKB_GSO_TCPV4 | SKB_GSO_TCPV6);
+ }
+ 
+ static inline void skb_gso_reset(struct sk_buff *skb)
+diff --git a/net/core/filter.c b/net/core/filter.c
+index 5ceba98069d4..f274620945ff 100644
+--- a/net/core/filter.c
++++ b/net/core/filter.c
+@@ -2804,7 +2804,7 @@ static int bpf_skb_proto_4_to_6(struct sk_buff *skb)
+ 	u32 off = skb_mac_header_len(skb);
+ 	int ret;
+ 
+-	if (!skb_is_gso_tcp(skb))
++	if (skb_is_gso(skb) && !skb_is_gso_tcp(skb))
+ 		return -ENOTSUPP;
+ 
+ 	ret = skb_cow(skb, len_diff);
+@@ -2845,7 +2845,7 @@ static int bpf_skb_proto_6_to_4(struct sk_buff *skb)
+ 	u32 off = skb_mac_header_len(skb);
+ 	int ret;
+ 
+-	if (!skb_is_gso_tcp(skb))
++	if (skb_is_gso(skb) && !skb_is_gso_tcp(skb))
+ 		return -ENOTSUPP;
+ 
+ 	ret = skb_unclone(skb, GFP_ATOMIC);
+@@ -2970,7 +2970,7 @@ static int bpf_skb_net_grow(struct sk_buff *skb, u32 len_diff)
+ 	u32 off = skb_mac_header_len(skb) + bpf_skb_net_base_len(skb);
+ 	int ret;
+ 
+-	if (!skb_is_gso_tcp(skb))
++	if (skb_is_gso(skb) && !skb_is_gso_tcp(skb))
+ 		return -ENOTSUPP;
+ 
+ 	ret = skb_cow(skb, len_diff);
+@@ -2999,7 +2999,7 @@ static int bpf_skb_net_shrink(struct sk_buff *skb, u32 len_diff)
+ 	u32 off = skb_mac_header_len(skb) + bpf_skb_net_base_len(skb);
+ 	int ret;
+ 
+-	if (!skb_is_gso_tcp(skb))
++	if (skb_is_gso(skb) && !skb_is_gso_tcp(skb))
+ 		return -ENOTSUPP;
+ 
+ 	ret = skb_unclone(skb, GFP_ATOMIC);
+-- 
+cgit 1.2-0.3.lf.el7
+

--- a/net-next-patches/bpf-map-alloc.patch
+++ b/net-next-patches/bpf-map-alloc.patch
@@ -1,0 +1,84 @@
+From 66dd42f9e038c42384d552932f2669f29e74c30f Mon Sep 17 00:00:00 2001
+From: Martynas Pumputis <m@lambda.lt>
+Date: Mon, 11 Mar 2019 20:00:06 +0100
+Subject: [PATCH v3 bpf] bpf: Try harder when allocating memory for large maps
+
+It has been observed that sometimes a higher order memory allocation
+for BPF maps fails when there is no obvious memory pressure in a system.
+
+E.g. the map (BPF_MAP_TYPE_LRU_HASH, key=38, value=56, max_elems=524288)
+could not be created due to vmalloc unable to allocate 75497472B,
+when the system's memory consumption (in MB) was the following:
+
+    Total: 3942 Used: 837 (21.24%) Free: 138 Buffers: 239 Cached: 2727
+
+Later analysis [1] by Michal Hocko showed that the vmalloc was not trying
+to reclaim memory from the page cache and was failing prematurely due to
+__GFP_NORETRY.
+
+Considering dcda9b0471 ("mm, tree wide: replace __GFP_REPEAT by
+__GFP_RETRY_MAYFAIL with more useful semantic") and [1], we can replace
+__GFP_NORETRY with __GFP_RETRY_MAYFAIL, as it won't invoke OOM killer
+and will try harder to fulfil allocation requests.
+
+Unfortunately, replacing the body of the BPF map memory allocation
+function with the kvmalloc_node helper function is not an option at this
+point in time, given 1) kmalloc is non-optional for higher order
+allocations, and 2) passing __GFP_RETRY_MAYFAIL to the kmalloc would stress
+the slab allocator too much for large requests.
+
+The change has been tested with the workloads mentioned above and by
+observing oom_kill value from /proc/vmstat.
+
+[1]: https://lore.kernel.org/bpf/20190310071318.GW5232@dhcp22.suse.cz/
+
+Acked-by: Yonghong Song <yhs@fb.com>
+Signed-off-by: Martynas Pumputis <m@lambda.lt>
+---
+ kernel/bpf/syscall.c | 22 +++++++++++++++-------
+ 1 file changed, 15 insertions(+), 7 deletions(-)
+
+diff --git a/kernel/bpf/syscall.c b/kernel/bpf/syscall.c
+index 62f6bced3a3c..afca36f53c49 100644
+--- a/kernel/bpf/syscall.c
++++ b/kernel/bpf/syscall.c
+@@ -136,21 +136,29 @@ static struct bpf_map *find_and_alloc_map(union bpf_attr *attr)
+ 
+ void *bpf_map_area_alloc(size_t size, int numa_node)
+ {
+-	/* We definitely need __GFP_NORETRY, so OOM killer doesn't
+-	 * trigger under memory pressure as we really just want to
+-	 * fail instead.
++	/* We really just want to fail instead of triggering OOM killer
++	 * under memory pressure, therefore we set __GFP_NORETRY to kmalloc,
++	 * which is used for lower order allocation requests.
++	 *
++	 * It has been observed that higher order allocation requests done by
++	 * vmalloc with __GFP_NORETRY being set might fail due to not trying
++	 * to reclaim memory from the page cache, thus we set
++	 * __GFP_RETRY_MAYFAIL to avoid such situations.
+ 	 */
+-	const gfp_t flags = __GFP_NOWARN | __GFP_NORETRY | __GFP_ZERO;
++
++	const gfp_t flags = __GFP_NOWARN | __GFP_ZERO;
+ 	void *area;
+ 
+ 	if (size <= (PAGE_SIZE << PAGE_ALLOC_COSTLY_ORDER)) {
+-		area = kmalloc_node(size, GFP_USER | flags, numa_node);
++		area = kmalloc_node(size, GFP_USER | __GFP_NORETRY | flags,
++				    numa_node);
+ 		if (area != NULL)
+ 			return area;
+ 	}
+ 
+-	return __vmalloc_node_flags_caller(size, numa_node, GFP_KERNEL | flags,
+-					   __builtin_return_address(0));
++	return __vmalloc_node_flags_caller(size, numa_node,
++					   GFP_KERNEL | __GFP_RETRY_MAYFAIL |
++					   flags, __builtin_return_address(0));
+ }
+ 
+ void bpf_map_area_free(void *area)
+-- 
+2.21.0
+

--- a/provision/ubuntu/kernel-next.sh
+++ b/provision/ubuntu/kernel-next.sh
@@ -11,8 +11,12 @@ sudo apt-get install -y --allow-downgrades \
 git clone --depth 1 git://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git $HOME/k
 cd $HOME/k
 
+git apply < /tmp/bpf-map-alloc.patch
+git apply < /tmp/bpf-gso.patch
+
 cp /boot/config-`uname -r` .config
 make oldconfig && make prepare
+
 
 ./scripts/config --module CONFIG_VBOXGUEST
 ./scripts/config --disable CONFIG_DEBUG_INFO


### PR DESCRIPTION
To make Cilium integration tests to work on `ubuntu-next`, we need to manually apply the following patches (both accepted) until they get merged to the bpf-next tree:

- bpf-map-alloc.patch: Fix BPF map memory allocations: https://lore.kernel.org/bpf/efeee51e-bb64-333d-7091-5c768c13e5e9@iogearbox.net/.
- bpf-gso.patch: Fix NAT46: https://lore.kernel.org/bpf/20190313191250.158955-6-sashal@kernel.org/.

Once they have been merged, I will create a new PR to remove the patches.