### PR TITLE
bump to go 1.12.1

### DIFF
--- a/provision/env.bash
+++ b/provision/env.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export GOLANG_VERSION="1.12"
+export GOLANG_VERSION="1.12.1"
 export GOLANG_VERSION_MINOR="1.12"
 export ETCD_VERSION="v3.1.0"
 export DOCKER_COMPOSE_VERSION="1.16.1"

--- a/provision/pull-images.sh
+++ b/provision/pull-images.sh
@@ -59,8 +59,8 @@ if [ -z "${NAME_PREFIX}" ]; then
         gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.10 \
         gcr.io/google_samples/gb-redisslave:v1 \
         k8s.gcr.io/coredns:1.2.6 \
-        quay.io/cilium/cilium-builder:2019-02-26 \
-        quay.io/cilium/cilium-runtime:2019-02-26 \
+        quay.io/cilium/cilium-builder:2019-03-16 \
+        quay.io/cilium/cilium-runtime:2019-03-16 \
         quay.io/coreos/etcd:v3.3.9 \
         quay.io/coreos/hyperkube:v1.7.6_coreos.0; \
     do


### PR DESCRIPTION
As well bump image tags that are built with go 1.12.1

Signed-off-by: André Martins <andre@cilium.io>