### PR TITLE
opensuse: Install cilium-envoy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,13 +26,13 @@ pipeline {
     }
 
     stages {
-        //stage('OpenSuse') {
-        //    steps {
-        //        sh 'git submodule update --init --recursive'
-        //        sh 'make clean DISTRIBUTION=opensuse'
-        //        sh 'make build DISTRIBUTION=opensuse'
-        //    }
-        //}
+        stage('OpenSuse') {
+            steps {
+                sh 'git submodule update --init --recursive'
+                sh 'make clean DISTRIBUTION=opensuse'
+                sh 'make build DISTRIBUTION=opensuse'
+            }
+        }
         stage('Ubuntu') {
             steps {
                 sh 'echo "${JQ}"'

--- a/provision/opensuse/install.sh
+++ b/provision/opensuse/install.sh
@@ -14,7 +14,9 @@ zypper -n --gpg-auto-import-key in --no-recommends \
         binutils \
         binutils-devel \
         bmon \
+        boringssl-devel \
         ca-certificates-mozilla \
+        cilium-proxy \
         clang \
         coreutils \
         cri-o \
@@ -27,3 +29,7 @@ zypper -n --gpg-auto-import-key in --no-recommends \
         jq \
         llvm \
     && zypper clean
+
+# Disable Envoy installation from Docker image. It's linked agains a different
+# version of glibc. For openSUSE we install Envoy from packages.
+echo "export DISABLE_ENVOY_INSTALLATION=1" >> /home/vagrant/.bashrc


### PR DESCRIPTION
Cilium proxy is already packaged in openSUSE[0]. Envoy which is shipped
in Ubuntu docker image is linked against a different version of glibc,
so let's use Envoy/cilium-proxy from packages instead of Docker image.

[0] https://build.opensuse.org/package/show/devel:kubic/cilium-proxy

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>