### PR TITLE
Cache etcd-operator:v0.9.4 image

### DIFF
--- a/provision/pull-images.sh
+++ b/provision/pull-images.sh
@@ -64,7 +64,8 @@ if [ -z "${NAME_PREFIX}" ]; then
         quay.io/cilium/cilium-builder:2019-03-16 \
         quay.io/cilium/cilium-runtime:2019-03-16 \
         quay.io/coreos/etcd:v3.3.11 \
-        quay.io/coreos/hyperkube:v1.7.6_coreos.0; \
+        quay.io/coreos/hyperkube:v1.7.6_coreos.0 \
+        quay.io/coreos/etcd-operator:v0.9.4; \
     do
           echo "pulling image: $img"
           sudo docker pull "${img}" &


### PR DESCRIPTION
Cache the image \[1\] in a VM image, as it used by the Cilium CI. https://github.com/cilium/cilium/issues/7740 could have been avoided if we had cached the image.

\[1\]: https://github.com/cilium/cilium-etcd-operator/blob/v2.0.6/pkg/defaults/const.go#L31

Signed-off-by: Martynas Pumputis <m@lambda.lt>