### PR TITLE
Add bpftool

### DIFF
--- a/cilium-ubuntu-next.json
+++ b/cilium-ubuntu-next.json
@@ -89,6 +89,13 @@
       "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
       "expect_disconnect": true,
       "scripts": [
+          "provision/ubuntu/kernel-next-bpftool.sh"
+      ]
+    },{
+      "type": "shell",
+      "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
+      "expect_disconnect": true,
+      "scripts": [
           "provision/ubuntu/kernel-next.sh"
       ]
     },{

--- a/cilium-ubuntu.json
+++ b/cilium-ubuntu.json
@@ -87,6 +87,13 @@
       "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
       "expect_disconnect": true,
       "scripts": [
+          "provision/ubuntu/kernel-next-bpftool.sh"
+      ]
+    },{
+      "type": "shell",
+      "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
+      "expect_disconnect": true,
+      "scripts": [
           "provision/ubuntu/kernel.sh"
       ]
     },{

--- a/provision/opensuse/install.sh
+++ b/provision/opensuse/install.sh
@@ -14,6 +14,7 @@ zypper -n --gpg-auto-import-key in --no-recommends \
         binutils \
         binutils-devel \
         bmon \
+        bpftool \
         ca-certificates-mozilla \
         clang \
         coreutils \

--- a/provision/ubuntu/kernel-next-bpftool.sh
+++ b/provision/ubuntu/kernel-next-bpftool.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -xe
+
+export 'KCONFIG'=${KCONFIG:-"config-`uname -r`"}
+
+sudo apt-get install -y --allow-downgrades \
+    pkg-config bison flex build-essential gcc libssl-dev \
+    libelf-dev bc
+
+git clone --depth 1 git://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git $HOME/k
+
+cd $HOME/k/tools/bpf/bpftool
+make
+sudo make install

--- a/provision/ubuntu/kernel-next.sh
+++ b/provision/ubuntu/kernel-next.sh
@@ -4,11 +4,6 @@ set -xe
 
 export 'KCONFIG'=${KCONFIG:-"config-`uname -r`"}
 
-sudo apt-get install -y --allow-downgrades \
-    pkg-config bison flex build-essential gcc libssl-dev \
-    libelf-dev bc
-
-git clone --depth 1 git://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git $HOME/k
 cd $HOME/k
 
 cp /boot/config-`uname -r` .config
@@ -42,9 +37,5 @@ sudo make -j$(nproc) deb-pkg
 cd ..
 sudo dpkg -i linux-*.deb
 sudo ln -sf /boot/System.map-$(uname -r) /boot/System.map
-
-cd $HOME/k/tools/bpf/bpftool
-make
-sudo make install
 
 sudo reboot


### PR DESCRIPTION
bpftool is going to be required for Cilium runtime for BPF feature
probes.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>