### PR TITLE
Install sonobuoy from release tarball or package

### DIFF
--- a/provision/env.bash
+++ b/provision/env.bash
@@ -5,6 +5,7 @@ export GOLANG_VERSION_MINOR="1.12"
 export ETCD_VERSION="v3.1.0"
 export DOCKER_COMPOSE_VERSION="1.16.1"
 export CONTAINERD_VERSION="1.2.4"
+export SONOBUOY_VERSION="0.14.2"
 export HOME_DIR=/home/vagrant
 export HOME=/home/vagrant
 export GOPATH="${HOME}/go"

--- a/provision/golang.sh
+++ b/provision/golang.sh
@@ -8,7 +8,6 @@ sudo -u vagrant -E bash -c "mkdir ${GOPATH} && \
 go get -u github.com/cilium/go-bindata/... && \
 go get -u github.com/google/gops && \
 go get github.com/subfuzion/envtpl/... && \
-go get -u github.com/gordonklaus/ineffassign && \
-go get -u github.com/heptio/sonobuoy"
+go get -u github.com/gordonklaus/ineffassign"
 
 sudo -E ln -s "${GOPATH}/bin/"* /usr/bin

--- a/provision/opensuse/install.sh
+++ b/provision/opensuse/install.sh
@@ -27,4 +27,5 @@ zypper -n --gpg-auto-import-key in --no-recommends \
         iproute2 \
         jq \
         llvm \
+        sonobuoy \
     && zypper clean

--- a/provision/ubuntu/install.sh
+++ b/provision/ubuntu/install.sh
@@ -145,6 +145,12 @@ EOF
 sudo systemctl enable etcd
 sudo systemctl start etcd
 
+# Install sonobuoy
+cd /tmp
+wget "https://github.com/heptio/sonobuoy/releases/download/v${SONOBUOY_VERSION}/sonobuoy_${SONOBUOY_VERSION}_linux_amd64.tar.gz"
+tar -xf "sonobuoy_${SONOBUOY_VERSION}_linux_amd64.tar.gz"
+sudo mv sonobuoy /usr/bin
+
 # Clean all downloaded packages
 sudo apt-get -y clean
 sudo apt-get -y autoclean


### PR DESCRIPTION
This is the follow up change which installs sonobuoy from release
tarball (on Ubuntu) or package (on openSUSE) instead of using `go get`.

Fixes: ecab44e403a6 ("Add sonobuoy")
Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>