### PR TITLE
Use bpf tree for ubuntu-next

### DIFF
--- a/provision/ubuntu/kernel-next-bpftool.sh
+++ b/provision/ubuntu/kernel-next-bpftool.sh
@@ -8,7 +8,7 @@ sudo apt-get install -y --allow-downgrades \
     pkg-config bison flex build-essential gcc libssl-dev \
     libelf-dev bc
 
-git clone --depth 1 git://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git $HOME/k
+git clone --depth 1 git://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf.git $HOME/k
 
 cd $HOME/k/tools/bpf/bpftool
 make


### PR DESCRIPTION
To facilitate testing of host-lb.