### PR TITLE
Remove trailing slash in ubuntu URL mirrors

### DIFF
--- a/cilium-ubuntu-next.json
+++ b/cilium-ubuntu-next.json
@@ -8,7 +8,7 @@
     "iso_checksum_type": "sha256",
     "iso_name": "ubuntu-18.04.2-server-amd64.iso",
     "memory": "4096",
-    "mirror": "http://cdimage.ubuntu.com/",
+    "mirror": "http://cdimage.ubuntu.com",
     "mirror_directory": "ubuntu/releases/18.04/release",
     "name": "ubuntu-18.04.2",
     "preseed_path": "preseed.cfg",

--- a/cilium-ubuntu.json
+++ b/cilium-ubuntu.json
@@ -7,7 +7,7 @@
     "iso_checksum_type": "sha256",
     "iso_name": "ubuntu-18.04.2-server-amd64.iso",
     "memory": "4096",
-    "mirror": "http://cdimage.ubuntu.com/",
+    "mirror": "http://cdimage.ubuntu.com",
     "mirror_directory": "ubuntu/releases/18.04/release",
     "name": "ubuntu-18.04.2",
     "preseed_path": "preseed.cfg",


### PR DESCRIPTION
With Packer v1.4.1, the trailing slash in mirror URL was causing a failure when downloading ISO files which lead to the invalid checksum:

```
==> virtualbox-iso: Retrieving ISO
==> virtualbox-iso: Trying
http://cdimage.ubuntu.com//ubuntu/releases/18.04/release/ubuntu-18.04.2-server-amd64.iso
==> virtualbox-iso: Trying
http://cdimage.ubuntu.com//ubuntu/releases/18.04/release/ubuntu-18.04.2-server-amd64.iso?checksum=sha256%3Aa2cb36dc010d98ad9253ea5ad5a07fd6b409e3412c48f1860536970b073c98f5
. 4.51 KiB / ?
[--------------------------------------------------------=----------------------------------------------------------------------------------------]
46.15% 0s
==> virtualbox-iso: Checksum did not match, removing
/home/brb/github/packer-ci-build/packer_cache/0e12e96c14de872d5159c48d34aa560e0ceb4509.iso
==> virtualbox-iso: Failed to remove cache file. Please remove manually:
/home/brb/github/packer-ci-build/packer_cache/0e12e96c14de872d5159c48d34aa560e0ceb4509.iso
==> virtualbox-iso: error downloading ISO: [Checksums did not match for
/tmp/getter883796418/temp.
==> virtualbox-iso: Expected:
a2cb36dc010d98ad9253ea5ad5a07fd6b409e3412c48f1860536970b073c98f5
==> virtualbox-iso: Got:
cd20c76a09e02cf961928b529dc9fb9413886be96560f4a64760b67cb4ae2d20
==> virtualbox-iso: *sha256.digest]
==> virtualbox-iso: leaving retrieve loop for ISO
Build 'virtualbox-iso' errored: error downloading ISO: [Checksums did
not match for /tmp/getter883796418/temp.
Expected:
a2cb36dc010d98ad9253ea5ad5a07fd6b409e3412c48f1860536970b073c98f5
Got: cd20c76a09e02cf961928b529dc9fb9413886be96560f4a64760b67cb4ae2d20
*sha256.digest]
```