### PR TITLE
ubuntu-next: Disable overlayfs index

### DIFF
--- a/provision/ubuntu/kernel-next.sh
+++ b/provision/ubuntu/kernel-next.sh
@@ -9,7 +9,6 @@ cd $HOME/k
 cp /boot/config-`uname -r` .config
 make oldconfig && make prepare
 
-
 ./scripts/config --module CONFIG_VBOXGUEST
 ./scripts/config --disable CONFIG_DEBUG_INFO
 ./scripts/config --disable CONFIG_DEBUG_KERNEL
@@ -31,7 +30,7 @@ make oldconfig && make prepare
 ./scripts/config --enable CONFIG_HAVE_EBPF_JIT
 ./scripts/config --module CONFIG_NETDEVSIM
 ./scripts/config --module CONFIG_TLS
-
+./scripts/config --disable CONFIG_OVERLAY_FS_INDEX
 
 sudo make -j$(nproc) deb-pkg
 cd ..


### PR DESCRIPTION
This should prevent from the `/var/lib/docker/overlay2/ID/merged: device
or resource busy` error which was observed when testing the host-lb: https://github.com/cilium/cilium/pull/8100.

The workaround was suggested by https://github.com/moby/moby/issues/34672#issuecomment-347994879.