### PR TITLE
next: Disable overlayfs check for lowedir being in-use by upperdir/workdir

### DIFF
--- a/cilium-ubuntu-next.json
+++ b/cilium-ubuntu-next.json
@@ -85,6 +85,10 @@
   ],
   "provisioners": [
     {
+      "type": "file",
+      "source": "net-next-patches/",
+      "destination": "/tmp/"
+    },{
       "type": "shell",
       "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
       "expect_disconnect": true,

--- a/net-next-patches/disable-lowerdir-is-in-use-check.patch
+++ b/net-next-patches/disable-lowerdir-is-in-use-check.patch
@@ -1,0 +1,34 @@
+From 8b96aac1c127487f4b6bdf65f3486eda2a5af8d0 Mon Sep 17 00:00:00 2001
+From: Martynas Pumputis <m@lambda.lt>
+Date: Mon, 1 Jul 2019 16:45:47 +0200
+Subject: [PATCH] overlayfs: Disable l is in-use by u/w check
+
+Just to work around until Docker has fixed the underlying issue.
+
+Signed-off-by: Martynas Pumputis <m@lambda.lt>
+---
+ fs/overlayfs/super.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/fs/overlayfs/super.c b/fs/overlayfs/super.c
+index b368e2e102fa..7bba0e92d7ad 100644
+--- a/fs/overlayfs/super.c
++++ b/fs/overlayfs/super.c
+@@ -1314,10 +1314,10 @@ static int ovl_get_lower_layers(struct super_block *sb, struct ovl_fs *ofs,
+ 			goto out;
+ 
+ 		err = -EBUSY;
+-		if (ovl_is_inuse(stack[i].dentry)) {
+-			pr_err("overlayfs: lowerdir is in-use as upperdir/workdir\n");
+-			goto out;
+-		}
++		//if (ovl_is_inuse(stack[i].dentry)) {
++		//	pr_err("overlayfs: lowerdir is in-use as upperdir/workdir\n");
++		//	goto out;
++		//}
+ 
+ 		err = ovl_setup_trap(sb, stack[i].dentry, &trap, "lowerdir");
+ 		if (err)
+-- 
+2.21.0
+

--- a/provision/ubuntu/kernel-next.sh
+++ b/provision/ubuntu/kernel-next.sh
@@ -30,7 +30,6 @@ make oldconfig && make prepare
 ./scripts/config --enable CONFIG_HAVE_EBPF_JIT
 ./scripts/config --module CONFIG_NETDEVSIM
 ./scripts/config --module CONFIG_TLS
-./scripts/config --disable CONFIG_OVERLAY_FS_INDEX
 
 sudo make -j$(nproc) deb-pkg
 cd ..

--- a/provision/ubuntu/kernel-next.sh
+++ b/provision/ubuntu/kernel-next.sh
@@ -6,6 +6,8 @@ export 'KCONFIG'=${KCONFIG:-"config-`uname -r`"}
 
 cd $HOME/k
 
+git apply < /tmp/disable-lowerdir-is-in-use-check.patch
+
 cp /boot/config-`uname -r` .config
 make oldconfig && make prepare
 


### PR DESCRIPTION
https://github.com/torvalds/linux/commit/146d62e5a5867fbf84490d82455718bfb10fe824 introduced a check for an overlayfs lowerdir being in-use by upperdir/workdir which makes Docker 18.09 to fail when pushing "k8s1:5000/cilium/cilium-dev" on the latest RC kernel.

The symptom is docker-push failing with `/var/lib/docker/overlay2/$DIR/merged: device or resource busy` and dmesg having the `overlayfs: lowerdir is in-use as upperdir/workdir` log entry.

This PR patches the kernel to disable the check until Docker has fixed the underlying issue. The included patch is NOT meant to be upstreamed.

Also, we re-enable the overlayfs index since Docker disables it by default.
