### PR TITLE
update golang to 1.13.4

### DIFF
--- a/provision/env.bash
+++ b/provision/env.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export GOLANG_VERSION="1.13.3"
+export GOLANG_VERSION="1.13.4"
 export GOLANG_VERSION_MINOR="1.13"
 export ETCD_VERSION="v3.1.0"
 export DOCKER_COMPOSE_VERSION="1.16.1"

--- a/provision/pull-images.sh
+++ b/provision/pull-images.sh
@@ -68,8 +68,8 @@ if [ -z "${NAME_PREFIX}" ]; then
         gcr.io/google_samples/gb-redisslave:v1 \
         k8s.gcr.io/coredns:1.2.6 \
         quay.io/cilium/cilium-envoy:d68c2561fae4c83960969a7aaa2a186c3b30e17a \
-        quay.io/cilium/cilium-builder:2019-09-26 \
-        quay.io/cilium/cilium-runtime:2019-09-26 \
+        quay.io/cilium/cilium-builder:2019-11-06 \
+        quay.io/cilium/cilium-runtime:2019-11-06 \
         quay.io/coreos/etcd:v3.3.11 \
         quay.io/coreos/etcd-operator:v0.9.4; \
 


### PR DESCRIPTION
Also update the base images that contain golang 1.13.4

Signed-off-by: André Martins <andre@cilium.io>