### PR TITLE
Temporarily switch to bpf.git tree

### DIFF
--- a/provision/ubuntu/kernel-next-bpftool.sh
+++ b/provision/ubuntu/kernel-next-bpftool.sh
@@ -8,7 +8,7 @@ sudo apt-get install -y --allow-downgrades \
     pkg-config bison flex build-essential gcc libssl-dev \
     libelf-dev bc
 
-git clone --depth 1 git://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git $HOME/k
+git clone --depth 1 git://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf.git $HOME/k
 
 cd $HOME/k/tools/bpf/bpftool
 make


### PR DESCRIPTION
To include the patch \[1\]. Once it has been included into bpf-next.git, we will switch back the tree.

\[1\]: https://git.kernel.org/pub/scm/linux/kernel/git/davem/net.git/commit/?id=cc52d9140aa920d8d61c7f6de3fff5fea6692ea9