### PR TITLE
ubuntu-next: Pin net-next kernel version to v5.4

### DIFF
--- a/provision/pull-images.sh
+++ b/provision/pull-images.sh
@@ -71,8 +71,8 @@ if [ -z "${NAME_PREFIX}" ]; then
         gcr.io/google_samples/gb-redisslave:v1 \
         k8s.gcr.io/coredns:1.2.6 \
         quay.io/cilium/cilium-envoy:c16d0f195d4fa5e26c3a7cff9a27fc69a13437c5 \
-        quay.io/cilium/cilium-builder:2019-12-11 \
-        quay.io/cilium/cilium-runtime:2020-01-14 \
+        quay.io/cilium/cilium-builder:2020-01-14 \
+        quay.io/cilium/cilium-runtime:2020-01-21 \
         quay.io/coreos/etcd:v3.2.17 \
         quay.io/coreos/etcd-operator:v0.9.4; \
 

--- a/provision/ubuntu/kernel-next-bpftool.sh
+++ b/provision/ubuntu/kernel-next-bpftool.sh
@@ -8,7 +8,7 @@ sudo apt-get install -y --allow-downgrades \
     pkg-config bison flex build-essential gcc libssl-dev \
     libelf-dev bc
 
-git clone --depth 1 git://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git $HOME/k
+git clone --branch v5.4 --depth 1 git://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git $HOME/k
 
 cd $HOME/k/tools/bpf/bpftool
 make


### PR DESCRIPTION
We need to rebuild ubuntu-next to contain the newest version of
iproute2. However, since Cilium currently fails to pass CI on the
5.5-rc's, we pin the net-next tag to v5.4 so we can have a new Vagrant
box without updating the kernel.

Additionally bumps the prepull images.
