### PR TITLE
ubuntu-next: Bump kernel to v5.5

### DIFF
--- a/provision/ubuntu/kernel-next-bpftool.sh
+++ b/provision/ubuntu/kernel-next-bpftool.sh
@@ -8,7 +8,7 @@ sudo apt-get install -y --allow-downgrades \
     pkg-config bison flex build-essential gcc libssl-dev \
     libelf-dev bc
 
-git clone --branch v5.4 --depth 1 git://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git $HOME/k
+git clone --branch v5.5 --depth 1 git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git $HOME/k
 
 cd $HOME/k/tools/bpf/bpftool
 make


### PR DESCRIPTION
The 5.5 kernel has been released \[1\]. Update ubuntu-next to use the kernel, so that we can test whether EPERM issue still persists \[2\].

\[1\]: https://lwn.net/Articles/810578/
\[2\]: https://github.com/cilium/cilium/pull/9657#issuecomment-577628794