### PR TITLE
Use Cilium fork of the kernel to build bpftool

### DIFF
--- a/provision/ubuntu/kernel-next-bpftool.sh
+++ b/provision/ubuntu/kernel-next-bpftool.sh
@@ -9,7 +9,8 @@ sudo apt-get install -y --allow-downgrades \
     libelf-dev bc
 
 git clone --branch v5.4 --depth 1 git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git $HOME/k
+git clone --depth 1 -b bpftool https://github.com/cilium/linux.git $HOME/k-bpftool
 
-cd $HOME/k/tools/bpf/bpftool
+cd $HOME/k-bpftool/tools/bpf/bpftool
 make
 sudo make install


### PR DESCRIPTION
Cilium fork of the Linux kernel contains necessary enhancements for
bpftool which are not avalavle upstream yet.

Ref: cilium/cilium#10048

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>