### PR TITLE
ubuntu: don't install libc6-dev

### DIFF
--- a/provision/ubuntu/install.sh
+++ b/provision/ubuntu/install.sh
@@ -47,7 +47,7 @@ sudo apt-get install -y --allow-downgrades \
     libdistro-info-perl libssl-dev \
     dh-systemd build-essential \
     clang-7 llvm-7 \
-    gcc make libc6-dev.i386 git-buildpackage \
+    gcc make git-buildpackage \
     pkg-config bison flex \
     zip g++ zlib1g-dev unzip python \
     libtool cmake coreutils m4 automake \


### PR DESCRIPTION
After cilium/cilium#10204 is merged, this is no longer needed.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>