### PR TITLE
net-next: Install perf

### DIFF
--- a/cilium-ubuntu-next.json
+++ b/cilium-ubuntu-next.json
@@ -96,6 +96,13 @@
       "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
       "expect_disconnect": true,
       "scripts": [
+          "provision/ubuntu/kernel-next-tools.sh"
+      ]
+    },{
+      "type": "shell",
+      "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
+      "expect_disconnect": true,
+      "scripts": [
           "provision/ubuntu/kernel-next.sh"
       ]
     },{

--- a/provision/ubuntu/kernel-next-tools.sh
+++ b/provision/ubuntu/kernel-next-tools.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -ex
+
+# Install perf tool
+
+cd $HOME/k/tools/perf
+make
+sudo make install

--- a/provision/ubuntu/kernel-next.sh
+++ b/provision/ubuntu/kernel-next.sh
@@ -32,7 +32,7 @@ make oldconfig && make prepare
 ./scripts/config --module CONFIG_TLS
 ./scripts/config --enable CONFIG_VBOXSF_FS
 
-sudo make -j$(nproc) deb-pkg
+make -j$(nproc) deb-pkg
 cd ..
 sudo dpkg -i linux-*.deb
 sudo ln -sf /boot/System.map-$(uname -r) /boot/System.map


### PR DESCRIPTION
Install perf into ubuntu-next machine which can be used to troubleshoot packet drops on CI machines (`perf record -g -a -e skb:kfree_skb && perf script`).