### PR TITLE
Install bpftool after install.sh script

### DIFF
--- a/cilium-ubuntu-next.json
+++ b/cilium-ubuntu-next.json
@@ -85,27 +85,6 @@
   ],
   "provisioners": [
     {
-      "type": "shell",
-      "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
-      "expect_disconnect": true,
-      "scripts": [
-          "provision/ubuntu/kernel-next-bpftool.sh"
-      ]
-    },{
-      "type": "shell",
-      "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
-      "expect_disconnect": true,
-      "scripts": [
-          "provision/ubuntu/kernel-next-tools.sh"
-      ]
-    },{
-      "type": "shell",
-      "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
-      "expect_disconnect": true,
-      "scripts": [
-          "provision/ubuntu/kernel-next.sh"
-      ]
-    },{
       "type": "file",
       "source": "provision/env.bash",
       "destination": "/tmp/env.bash"
@@ -121,6 +100,9 @@
       "scripts": [
           "provision/vagrant.sh",
           "provision/ubuntu/install.sh",
+          "provision/ubuntu/kernel-next-bpftool.sh",
+          "provision/ubuntu/kernel-next-tools.sh",
+          "provision/ubuntu/kernel-next.sh",
           "provision/golang.sh",
           "provision/swap.sh",
           "provision/registry.sh",

--- a/cilium-ubuntu.json
+++ b/cilium-ubuntu.json
@@ -87,13 +87,6 @@
       "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
       "expect_disconnect": true,
       "scripts": [
-          "provision/ubuntu/kernel-next-bpftool.sh"
-      ]
-    },{
-      "type": "shell",
-      "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
-      "expect_disconnect": true,
-      "scripts": [
           "provision/ubuntu/kernel.sh"
       ]
     },{
@@ -112,6 +105,7 @@
       "scripts": [
           "provision/vagrant.sh",
           "provision/ubuntu/install.sh",
+          "provision/ubuntu/kernel-next-bpftool.sh",
           "provision/golang.sh",
           "provision/swap.sh",
           "provision/registry.sh",


### PR DESCRIPTION
After introducing the "prog profile" command[0], bpftool needs clang to
build. Clang is installed in install.sh script. Thus the
kernel-next-bpftool.sh scripts needs to be executed after install.sh.

[0] https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git/commit/?id=47c09d6a9f6794caface4ad50930460b82d7c670

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>