### PR TITLE
Use doc. dependencies from cilium repo.

### DIFF
--- a/provision/ubuntu/install.sh
+++ b/provision/ubuntu/install.sh
@@ -89,8 +89,7 @@ cd ../../..
 rm -fr llvm/
 
 # Documentation dependencies
-sudo -H pip3 install sphinx sphinxcontrib-httpdomain sphinxcontrib-openapi sphinx-rtd-theme sphinx-tabs recommonmark
-sudo -H pip3 install yamllint
+sudo -H pip3 install -r https://raw.githubusercontent.com/cilium/cilium/master/Documentation/requirements.txt
 
 #IP Route
 cd /tmp


### PR DESCRIPTION
The images are regularly missing documentation dependencies because they are currently hardcoded in the VM provisioning scripts. This commit changes the script to use the latest list of documentation dependencies from the cilium repository.

CI tests currently need #195. I tested the VM image provisioning locally in the meantime.

Fixes #78.

/cc @mrostecki 