### PR TITLE
ubuntu: Switch to 'bpf' tree to pick up fixes

### DIFF
--- a/provision/ubuntu/kernel-next-bpftool.sh
+++ b/provision/ubuntu/kernel-next-bpftool.sh
@@ -8,7 +8,7 @@ sudo apt-get install -y --allow-downgrades \
     pkg-config bison flex build-essential gcc libssl-dev \
     libelf-dev bc
 
-git clone --depth 1 git://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git $HOME/k
+git clone --depth 1 git://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf.git $HOME/k
 
 cd $HOME/k/tools/bpf/bpftool
 make


### PR DESCRIPTION
Switch to the bpf tree to pick up the fix 8e368dc72e86 ("bpf: Fix use of
sk->sk_reuseport from sk_assign"). We can switch back to bpf-next after
it's merged there.