### PR TITLE
provision: pull latest cilium base images

### DIFF
--- a/provision/pull-images.sh
+++ b/provision/pull-images.sh
@@ -62,8 +62,8 @@ if [ -z "${NAME_PREFIX}" ]; then
         gcr.io/google-samples/gb-frontend:v4 \
         gcr.io/google_samples/gb-redisslave:v1 \
         quay.io/cilium/cilium-envoy:a3385205ad620550b35d3b0b651e40898386e6e3 \
-        quay.io/cilium/cilium-builder:2020-04-02 \
-        quay.io/cilium/cilium-runtime:2020-03-25 \
+        quay.io/cilium/cilium-builder:2020-04-16 \
+        quay.io/cilium/cilium-runtime:2020-04-16 \
         quay.io/coreos/etcd:v3.2.17 \
         quay.io/coreos/etcd-operator:v0.9.4; \
 


### PR DESCRIPTION
This will pull in Go 1.14.2 via cilium/cilium#10912 and the build llvm
changes from cilium/cilium#10956