### PR TITLE
golang: Add opennota/check tools

### DIFF
--- a/provision/golang.sh
+++ b/provision/golang.sh
@@ -7,6 +7,7 @@ set -e
 sudo -u vagrant -E bash -c "mkdir ${GOPATH} && \
 go get -u github.com/google/gops && \
 go get github.com/subfuzion/envtpl/... && \
-go get -u github.com/gordonklaus/ineffassign"
+go get -u github.com/gordonklaus/ineffassign && \
+go get -u gitlab.com/opennota/check/cmd/..."
 
 sudo -E ln -s "${GOPATH}/bin/"* /usr/bin


### PR DESCRIPTION
Cilium is going to use the varcheck tool from opennota/check repository.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>