### PR TITLE
pull latest cilium images, bump Go version, don't preseed kernel headers/sources

### DIFF
--- a/http/preseed.cfg
+++ b/http/preseed.cfg
@@ -26,7 +26,7 @@ d-i passwd/user-uid string 1000
 d-i passwd/user-password password vagrant
 d-i passwd/user-password-again password vagrant
 d-i passwd/username string vagrant
-d-i pkgsel/include string openssh-server cryptsetup build-essential libssl-dev libreadline-dev zlib1g-dev linux-source dkms nfs-common linux-headers-$(uname -r) perl
+d-i pkgsel/include string openssh-server cryptsetup build-essential libssl-dev libreadline-dev zlib1g-dev dkms nfs-common perl
 d-i pkgsel/install-language-support boolean false
 d-i pkgsel/update-policy select none
 d-i pkgsel/upgrade select full-upgrade

--- a/provision/env.bash
+++ b/provision/env.bash
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-export GOLANG_VERSION="1.14.1"
-export GOLANG_VERSION_MINOR="1.14"
+export GOLANG_VERSION="1.14.3"
 export ETCD_VERSION="v3.1.0"
 export DOCKER_COMPOSE_VERSION="1.16.1"
 export CONTAINERD_VERSION="1.2.4"

--- a/provision/pull-images.sh
+++ b/provision/pull-images.sh
@@ -24,7 +24,6 @@ if [ -z "${NAME_PREFIX}" ]; then
         docker.io/cilium/cilium:v1.6 \
         docker.io/cilium/demo-client:latest \
         docker.io/cilium/demo-httpd:latest \
-        docker.io/cilium/docker-bind:v0.1 \
         docker.io/cilium/echoserver:1.10 \
         docker.io/cilium/echoserver-udp:v2020.01.30 \
         docker.io/cilium/istio_pilot:1.5.4 \
@@ -37,7 +36,6 @@ if [ -z "${NAME_PREFIX}" ]; then
         docker.io/cilium/starwars:v1.0 \
         docker.io/cilium/python-bmemcached:v0.0.1 \
         docker.io/cilium/dnssec-client:v0.1 \
-        docker.io/cilium/docker-bind:v0.1 \
         docker.io/cilium/docker-bind:v0.3 \
         docker.io/digitalwonderland/zookeeper:latest \
         docker.io/istio/examples-bookinfo-details-v1:1.6.0 \

--- a/provision/pull-images.sh
+++ b/provision/pull-images.sh
@@ -62,8 +62,8 @@ if [ -z "${NAME_PREFIX}" ]; then
         gcr.io/google-samples/gb-frontend:v4 \
         gcr.io/google_samples/gb-redisslave:v1 \
         quay.io/cilium/cilium-envoy:a3385205ad620550b35d3b0b651e40898386e6e3 \
-        quay.io/cilium/cilium-builder:2020-05-18 \
-        quay.io/cilium/cilium-runtime:2020-05-18 \
+        quay.io/cilium/cilium-builder:2020-05-20 \
+        quay.io/cilium/cilium-runtime:2020-05-20 \
         quay.io/cilium/hubble:v0.5.1 \
         quay.io/coreos/etcd:v3.2.17 \
         quay.io/coreos/etcd:v3.4.7 \


### PR DESCRIPTION
* provision: pull latest cilium images
* provision: update Go to 1.14.3
* don't install kernel headers and source in preseed

Please see individual commit for details