### PR TITLE
provision/ubuntu: only build clang and llc targets

### DIFF
--- a/provision/ubuntu/install.sh
+++ b/provision/ubuntu/install.sh
@@ -94,7 +94,7 @@ cd llvm
 git checkout -b d941df363d1cb621a3836b909c37d79f2a3e27e2 d941df363d1cb621a3836b909c37d79f2a3e27e2
 cd llvm/build
 cmake .. -G "Ninja" -DLLVM_TARGETS_TO_BUILD="BPF" -DLLVM_ENABLE_PROJECTS="clang" -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DLLVM_BUILD_RUNTIME=OFF
-ninja
+ninja clang llc
 strip bin/clang
 strip bin/llc
 cp bin/clang /usr/bin/clang


### PR DESCRIPTION
Specify only the targets we need from the llvm build, namely `clang` and
`llc`. This reduces the amount of objects to build by ~300 and thus
also reduces build time a bit.

Same as cilium/cilium#10956

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>