### PR TITLE
llvm: re-enable x86 next to bpf backend

### DIFF
--- a/provision/ubuntu/install.sh
+++ b/provision/ubuntu/install.sh
@@ -93,7 +93,7 @@ mkdir -p llvm/llvm/build/install
 cd llvm
 git checkout -b d941df363d1cb621a3836b909c37d79f2a3e27e2 d941df363d1cb621a3836b909c37d79f2a3e27e2
 cd llvm/build
-cmake .. -G "Ninja" -DLLVM_TARGETS_TO_BUILD="BPF" -DLLVM_ENABLE_PROJECTS="clang" -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DLLVM_BUILD_RUNTIME=OFF
+cmake .. -G "Ninja" -DLLVM_TARGETS_TO_BUILD="BPF;X86" -DLLVM_ENABLE_PROJECTS="clang" -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DLLVM_BUILD_RUNTIME=OFF
 ninja clang llc
 strip bin/clang
 strip bin/llc


### PR DESCRIPTION
Given this is used for dev VMs, it's useful to have x86 around as well
since it's used e.g. in the BPF unit tests that the CI runs. So running
it locally, x86 backend would be needed, too.

Note that this does not affect the cilium-runtime image which does not
have the x86 backend (and will never have it again).

Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>