### PR TITLE
provision: clean up list of pre-pulled images

### DIFF
--- a/provision/pull-images.sh
+++ b/provision/pull-images.sh
@@ -12,9 +12,8 @@ done
 
 if [ -z "${NAME_PREFIX}" ]; then
     for img in \
-        busybox:1.30.1 \
         busybox:1.31.1 \
-        docker.io/byrnedo/alpine-curl:0.1.7 \
+        docker.io/byrnedo/alpine-curl:0.1.8 \
         k8s.gcr.io/coredns:1.2.2 \
         k8s.gcr.io/coredns:1.2.6 \
         k8s.gcr.io/coredns:1.3.1 \
@@ -44,14 +43,11 @@ if [ -z "${NAME_PREFIX}" ]; then
         docker.io/istio/examples-bookinfo-reviews-v1:1.6.0 \
         docker.io/istio/examples-bookinfo-reviews-v2:1.6.0 \
         docker.io/library/alpine:3.9 \
-        docker.io/library/busybox:1.28.0 \
         docker.io/library/cassandra:3.11.3 \
         docker.io/library/httpd:2.4.34 \
         docker.io/library/memcached:1.5.11 \
         docker.io/library/redis:4.0.11 \
         docker.io/library/registry:2.6.2 \
-        docker.io/prom/prometheus:v2.12.0 \
-        docker.io/prom/statsd-exporter:v0.6.0 \
         docker.io/spotify/kafkaproxy:latest \
         docker.io/tgraf/netperf:v1.0 \
         docker.io/wurstmeister/kafka:2.11-0.11.0.3 \
@@ -65,7 +61,6 @@ if [ -z "${NAME_PREFIX}" ]; then
         quay.io/cilium/hubble:v0.5.1 \
         quay.io/coreos/etcd:v3.2.17 \
         quay.io/coreos/etcd:v3.4.7 \
-        quay.io/coreos/etcd-operator:v0.9.4; \
 
     do
           echo "pulling image: $img"


### PR DESCRIPTION
With cilium/cilium#11728 all alpine-curl and busybox image versions are
unified, so only alpine-curl:0.1.8 and busybox:1.31.1 need to be
pre-pulled

docker.io/prom/prometheus and docker.io/prom/statsd-exporter are no
longer used after cilium/cilium#10851 and cilium/cilium#7712, so they
don't need to be pre-pulled.

quay.io/coreos/etcd-operator:v0.9.4 is used nowhere in CI, drop it.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>