### PR TITLE
provision: Bump Hubble CLI to 0.6.0

### DIFF
--- a/provision/ubuntu/install.sh
+++ b/provision/ubuntu/install.sh
@@ -5,7 +5,7 @@ set -eu
 source "${ENV_FILEPATH}"
 export 'IPROUTE_BRANCH'=${IPROUTE_BRANCH:-"static-data"}
 export 'IPROUTE_GIT'=${IPROUTE_GIT:-https://github.com/cilium/iproute2}
-export 'HUBBLE_BRANCH'=${HUBBLE_BRANCH:-"v0.5.1"}
+export 'HUBBLE_BRANCH'=${HUBBLE_BRANCH:-"v0.6.0"}
 export 'HUBBLE_GIT'=${HUBBLE_GIT:-https://github.com/cilium/hubble}
 export 'GUESTADDITIONS'=${GUESTADDITIONS:-""}
 NETNEXT="${NETNEXT:-false}"


### PR DESCRIPTION
This is the newest Hubble CLI release.

Note: The pre-pulled 0.5 images will likely be removed in a separate PR once we have updated Cilium CI to not pull these images anymore.

Signed-off-by: Sebastian Wicki <sebastian@isovalent.com>