### PR TITLE
provision/ubuntu: disable unattended-upgrades

### DIFF
--- a/provision/ubuntu/install.sh
+++ b/provision/ubuntu/install.sh
@@ -37,6 +37,10 @@ if [ "${NETNEXT}" == "true" ]; then
     sudo rm $(which mount.vboxsf)
 fi
 
+# Disable unattended-upgrades to prevent it from holding the dpkg frontend lock
+sudo systemctl disable unattended-upgrades.service
+sudo systemctl stop unattended-upgrades.service
+
 echo "Provision a new server"
 sudo apt-get update
 sudo apt-get install -y --allow-downgrades \


### PR DESCRIPTION
CI runs occasionally fail with errors similar to:

```
    Could not get lock /var/lib/dpkg/lock-frontend - open (11: Resource
        temporarily unavailable)
    Unable to acquire the dpkg frontend lock
        (/var/lib/dpkg/lock-frontend), is another process using it?
```

This lock is typically held by `dpkg` or `apt` when they check for or proceed to updates. The two main suspects are usually:

- An aborted run of `dpkg` or `apt`, that would not have released the lock   on exit, or
- Automatic updates running in the background, for example with the `unattended-upgrades` package.

The logs did not raise any previous apt failure. Automatic updates may well be responsible for the lock being held. We do not want them running on test machines anyway, so let's disable `unattended-updates` altogether.