### PR TITLE
provision: install nodejs/npm and pull latest Cilium images

### DIFF
--- a/provision/pull-images.sh
+++ b/provision/pull-images.sh
@@ -20,7 +20,6 @@ if [ -z "${NAME_PREFIX}" ]; then
         k8s.gcr.io/coredns:1.6.2 \
         k8s.gcr.io/coredns:1.6.5 \
         docker.io/cilium/cc-grpc-demo:v2.0 \
-        docker.io/cilium/cilium:v1.6 \
         docker.io/cilium/demo-client:latest \
         docker.io/cilium/demo-httpd:latest \
         docker.io/cilium/echoserver:1.10 \
@@ -55,10 +54,10 @@ if [ -z "${NAME_PREFIX}" ]; then
         docker.io/metallb/speaker:v0.8.2 \
         gcr.io/google-samples/gb-frontend:v4 \
         gcr.io/google_samples/gb-redisslave:v1 \
-        quay.io/cilium/cilium-envoy:a3385205ad620550b35d3b0b651e40898386e6e3 \
-        quay.io/cilium/cilium-builder:2020-05-20 \
-        quay.io/cilium/cilium-runtime:2020-05-20 \
-        quay.io/cilium/hubble:v0.5.1 \
+        quay.io/cilium/cilium-envoy:a8f292139e923b205525feb2c8a4377005904776 \
+        quay.io/cilium/cilium-builder:2020-06-08 \
+        quay.io/cilium/cilium-runtime:2020-06-08 \
+        quay.io/cilium/hubble:v0.6.0 \
         quay.io/coreos/etcd:v3.2.17 \
         quay.io/coreos/etcd:v3.4.7 \
 

--- a/provision/ubuntu/install.sh
+++ b/provision/ubuntu/install.sh
@@ -66,6 +66,15 @@ sudo apt-get install -y --allow-downgrades \
     libseccomp2 libenchant1c2a ninja-build \
     golang-cfssl ntp
 
+# Install nodejs and npm, needed for the cilium rtd sphinx theme
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add -
+sudo add-apt-repository \
+   "deb [arch=amd64] https://deb.nodesource.com/node_12.x \
+   $(lsb_release -cs) \
+   main"
+sudo apt-get update
+sudo apt-get install -y nodejs
+
 # Install protoc from github release, as protobuf-compiler version in apt is quite old (e.g 3.0.0-9.1ubuntu1)
 cd /tmp
 wget -nv https://github.com/protocolbuffers/protobuf/releases/download/v3.11.4/protoc-3.11.4-linux-x86_64.zip


### PR DESCRIPTION
Building the vagrant images currently fails because
`setup.py install` for `sphinx-rtd-theme-cilium` needs `npm` and `nodejs`.
Install these in the provision script.

Also pull the latest Cilium images and drop the unused
docker.io/cilium/cilium:v1.6 image.