### PR TITLE
provision: Bump Hubble to v0.6.1

### DIFF
--- a/provision/env.bash
+++ b/provision/env.bash
@@ -4,6 +4,7 @@ export GOLANG_VERSION="1.14.3"
 export ETCD_VERSION="v3.1.0"
 export DOCKER_COMPOSE_VERSION="1.16.1"
 export CONTAINERD_VERSION="1.2.4"
+export HUBBLE_VERSION="0.6.1"
 export SONOBUOY_VERSION="0.14.2"
 export HOME_DIR=/home/vagrant
 export HOME=/home/vagrant

--- a/provision/pull-images.sh
+++ b/provision/pull-images.sh
@@ -57,7 +57,7 @@ if [ -z "${NAME_PREFIX}" ]; then
         quay.io/cilium/cilium-envoy:a8f292139e923b205525feb2c8a4377005904776 \
         quay.io/cilium/cilium-builder:2020-06-08 \
         quay.io/cilium/cilium-runtime:2020-06-08 \
-        quay.io/cilium/hubble:v0.6.0 \
+        quay.io/cilium/hubble:v0.6.1 \
         quay.io/coreos/etcd:v3.2.17 \
         quay.io/coreos/etcd:v3.4.7 \
 

--- a/provision/ubuntu/install.sh
+++ b/provision/ubuntu/install.sh
@@ -5,8 +5,6 @@ set -eu
 source "${ENV_FILEPATH}"
 export 'IPROUTE_BRANCH'=${IPROUTE_BRANCH:-"static-data"}
 export 'IPROUTE_GIT'=${IPROUTE_GIT:-https://github.com/cilium/iproute2}
-export 'HUBBLE_BRANCH'=${HUBBLE_BRANCH:-"v0.6.0"}
-export 'HUBBLE_GIT'=${HUBBLE_GIT:-https://github.com/cilium/hubble}
 export 'GUESTADDITIONS'=${GUESTADDITIONS:-""}
 NETNEXT="${NETNEXT:-false}"
 
@@ -194,10 +192,10 @@ sudo mv sonobuoy /usr/bin
 
 # Install hubble
 cd /tmp
-git clone -b ${HUBBLE_BRANCH} ${HUBBLE_GIT}
-cd /tmp/hubble
-make
-sudo make BINDIR=/usr/bin install
+wget "https://github.com/cilium/hubble/releases/download/v${HUBBLE_VERSION}/hubble-linux-amd64.tar.gz"
+wget "https://github.com/cilium/hubble/releases/download/v${HUBBLE_VERSION}/hubble-linux-amd64.tar.gz.sha256sum"
+sha256sum --check hubble-linux-amd64.tar.gz.sha256sum || exit 1
+sudo tar -xf "hubble-linux-amd64.tar.gz" -C /usr/bin hubble
 
 # Clean all downloaded packages
 sudo apt-get -y clean


### PR DESCRIPTION
In addition, downloads the binary artifacts from GitHub releases instead
of building it manually.

Signed-off-by: Sebastian Wicki <sebastian@isovalent.com>