### PR TITLE
Enable building of wireguard module on net-next

### DIFF
--- a/provision/pull-images.sh
+++ b/provision/pull-images.sh
@@ -22,7 +22,7 @@ if [ -z "${NAME_PREFIX}" ]; then
         docker.io/cilium/cc-grpc-demo:v2.0 \
         docker.io/cilium/demo-client:latest \
         docker.io/cilium/demo-httpd:latest \
-        docker.io/cilium/echoserver:1.10 \
+        docker.io/cilium/echoserver:1.10.1 \
         docker.io/cilium/echoserver-udp:v2020.01.30 \
         docker.io/cilium/istio_pilot:1.5.4 \
         docker.io/cilium/istio_proxy:1.5.4 \

--- a/provision/ubuntu/kernel-next.sh
+++ b/provision/ubuntu/kernel-next.sh
@@ -31,6 +31,7 @@ make oldconfig && make prepare
 ./scripts/config --module CONFIG_NETDEVSIM
 ./scripts/config --module CONFIG_TLS
 ./scripts/config --enable CONFIG_VBOXSF_FS
+./scripts/config --module CONFIG_WIREGUARD
 
 make -j$(nproc) deb-pkg
 cd ..


### PR DESCRIPTION
Also, while we are here, cache the `cilium/echoserver:1.10.1` image used by the Cilium CI.