### PR TITLE
provision: Install headers required for Clang

### DIFF
--- a/provision/ubuntu/install.sh
+++ b/provision/ubuntu/install.sh
@@ -110,6 +110,7 @@ strip bin/clang
 strip bin/llc
 cp bin/clang /usr/bin/clang
 cp bin/llc /usr/bin/llc
+cp -n lib/clang/11.0.0/include/*.h /usr/include/
 cd ../../..
 rm -fr llvm/
 


### PR DESCRIPTION
We need these header files to compile the BPF unit tests inside the development VMs.

Related: https://github.com/cilium/cilium/issues/11255
Fixes: #218