### PR TITLE
Add script which helps with bisecting kernel issues

### DIFF
--- a/provision/ubuntu/kernel-next-bpftool.sh.sed
+++ b/provision/ubuntu/kernel-next-bpftool.sh.sed
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -xe
+
+export 'KCONFIG'=${KCONFIG:-"config-`uname -r`"}
+
+sudo apt-get install -y --allow-downgrades \
+    pkg-config bison flex build-essential gcc libssl-dev \
+    libelf-dev bc
+
+git clone --depth 500 git://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git $HOME/k
+
+cd $HOME/k/tools/bpf/bpftool
+CHECKOUT
+make
+sudo make install

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -xe
+
+pushd ../bpf-next
+sha=$(git rev-parse HEAD)
+popd
+
+pushd ../packer-ci-build
+cat provision/ubuntu/kernel-next-bpftool.sh.sed | sed "s/CHECKOUT/git checkout ${sha}/" > provision/ubuntu/kernel-next-bpftool.sh
+chmod +x provision/ubuntu/kernel-next-bpftool.sh
+
+make build DISTRIBUTION=ubuntu-next
+popd


### PR DESCRIPTION
To use, you need to have kernel checked out in `../bpf-next` dir, then
run `git bisect start` in kernel dir, then run
`git bisect run../packer-ci-build/test.sh` to automatically look for
first kernel commit that breaks the build.