### PR TITLE
packer-ci-builds: Enable BTF debug info in kernel

### DIFF
--- a/provision/ubuntu/kernel-next.sh
+++ b/provision/ubuntu/kernel-next.sh
@@ -32,6 +32,7 @@ make oldconfig && make prepare
 ./scripts/config --module CONFIG_TLS
 ./scripts/config --enable CONFIG_VBOXSF_FS
 ./scripts/config --module CONFIG_WIREGUARD
+./scripts/config --enable CONFIG_DEBUG_INFO_BTF
 
 make -j$(nproc) deb-pkg
 cd ..


### PR DESCRIPTION
Working on and testing pahole, llvm, and other tooling requires BTF. For
example running bpf-next sefltests requires it to run all the tests
correctly. Lets add it to the list of kernel config options we enable
so we can run selftests and other tools from inside the bpf-next kernel
image.

Signed-off-by: John Fastabend <john.fastabend@gmail.com>