### PR TITLE
Revert "provision: Bump LLVM to 11.0.0"

### DIFF
--- a/provision/ubuntu/install.sh
+++ b/provision/ubuntu/install.sh
@@ -104,7 +104,7 @@ cd /tmp
 git clone -b master https://github.com/llvm/llvm-project.git llvm
 mkdir -p llvm/llvm/build/install
 cd llvm
-git checkout -b llvmorg-11.0.0 llvmorg-11.0.0
+git checkout -b d941df363d1cb621a3836b909c37d79f2a3e27e2 d941df363d1cb621a3836b909c37d79f2a3e27e2
 cd llvm/build
 cmake .. -G "Ninja" -DLLVM_TARGETS_TO_BUILD="BPF;X86" -DLLVM_ENABLE_PROJECTS="clang" -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DLLVM_BUILD_RUNTIME=OFF
 ninja clang llc


### PR DESCRIPTION
This reverts commit 15d6adbcb3d93aece8fe643245f5ec56e3e202ae.

We can't update to LLVM 11.0.0 just yet because we are hitting verifier issues for that version (and complexity issues for the LLVM trunk). I'm reverting this commit to unblock other image updates.