### PR TITLE
provision: Update Docker images

### DIFF
--- a/provision/pull-images.sh
+++ b/provision/pull-images.sh
@@ -20,16 +20,16 @@ if [ -z "${NAME_PREFIX}" ]; then
         k8s.gcr.io/coredns:1.6.2 \
         k8s.gcr.io/coredns:1.6.5 \
         docker.io/cilium/cc-grpc-demo:v3.0 \
-        docker.io/cilium/demo-client:latest \
-        docker.io/cilium/demo-httpd:latest \
+        docker.io/cilium/demo-client:1.0 \
+        docker.io/cilium/demo-httpd:1.0 \
         docker.io/cilium/dummylb:0.0.1 \
         docker.io/cilium/echoserver:1.10.1 \
         docker.io/cilium/echoserver-udp:v2020.01.30 \
         docker.io/cilium/istio_pilot:1.5.7 \
         docker.io/cilium/istio_proxy:1.5.7 \
         docker.io/cilium/json-mock:1.2 \
-        docker.io/cilium/kafkaclient2:latest \
-        docker.io/cilium/kafkaclient:latest \
+        docker.io/cilium/kafkaclient2:1.0 \
+        docker.io/cilium/kafkaclient:1.0 \
         docker.io/cilium/log-gatherer:v1.0 \
         docker.io/cilium/migrate-svc-test:v0.0.1 \
         docker.io/cilium/netperf:0.0.2 \
@@ -37,7 +37,7 @@ if [ -z "${NAME_PREFIX}" ]; then
         docker.io/cilium/python-bmemcached:v0.0.2 \
         docker.io/cilium/dnssec-client:v0.2 \
         docker.io/cilium/docker-bind:v0.3 \
-        docker.io/digitalwonderland/zookeeper:latest \
+        docker.io/cilium/zookeeper:1.0 \
         docker.io/istio/examples-bookinfo-details-v1:1.16.2 \
         docker.io/istio/examples-bookinfo-productpage-v1:0.2.3 \
         docker.io/istio/examples-bookinfo-ratings-v1:1.16.2 \
@@ -48,7 +48,7 @@ if [ -z "${NAME_PREFIX}" ]; then
         docker.io/library/memcached:1.6.6-alpine \
         docker.io/library/redis:6.0.5 \
         docker.io/library/registry:2.6.2 \
-        docker.io/spotify/kafkaproxy:latest \
+        docker.io/cilium/kafkaproxy:1.0 \
         docker.io/tgraf/netperf:v1.0 \
         docker.io/wurstmeister/kafka:2.11-0.11.0.3 \
         gcr.io/google-samples/gb-frontend:v6 \


### PR DESCRIPTION
Pull request https://github.com/cilium/cilium/pull/14093 removed all references to :latest in our tests, preferring stable image tags. This pull request updates the list of pre-pulled images accordingly.