### PR TITLE
Update istio and hubble

### DIFF
--- a/provision/env.bash
+++ b/provision/env.bash
@@ -3,6 +3,7 @@
 export GOLANG_VERSION="1.15.6"
 export ETCD_VERSION="v3.1.0"
 export CONTAINERD_VERSION="1.3.4"
+export HUBBLE_VERSION="0.7.1"
 export SONOBUOY_VERSION="0.14.2"
 export PROTOC_VERSION="3.12.4"
 export HOME_DIR=/home/vagrant

--- a/provision/pull-images.sh
+++ b/provision/pull-images.sh
@@ -25,8 +25,8 @@ if [ -z "${NAME_PREFIX}" ]; then
         docker.io/cilium/dummylb:0.0.1 \
         docker.io/cilium/echoserver:1.10.1 \
         docker.io/cilium/echoserver-udp:v2020.01.30 \
-        docker.io/cilium/istio_pilot:1.5.7 \
-        docker.io/cilium/istio_proxy:1.5.7 \
+        docker.io/cilium/istio_pilot:1.6.14 \
+        docker.io/cilium/istio_proxy:1.6.14 \
         docker.io/cilium/json-mock:1.2 \
         docker.io/cilium/kafkaclient2:1.0 \
         docker.io/cilium/kafkaclient:1.0 \

--- a/provision/pull-images.sh
+++ b/provision/pull-images.sh
@@ -56,6 +56,7 @@ if [ -z "${NAME_PREFIX}" ]; then
         quay.io/cilium/cilium-envoy:ccad480c59aa8b946d98aaf79f8e9e38d6731fdc \
         quay.io/cilium/cilium-builder:2021-01-14 \
         quay.io/cilium/cilium-runtime:2021-01-14 \
+        quay.io/cilium/hubble:v0.7.1 \
         quay.io/cilium/net-test:v1.0.0 \
         quay.io/coreos/etcd:v3.4.7 \
 

--- a/provision/ubuntu/install.sh
+++ b/provision/ubuntu/install.sh
@@ -6,8 +6,6 @@ source "${ENV_FILEPATH}"
 export 'IPROUTE_BRANCH'=${IPROUTE_BRANCH:-"static-data"}
 export 'IPROUTE_GIT'=${IPROUTE_GIT:-https://github.com/cilium/iproute2}
 export 'GUESTADDITIONS'=${GUESTADDITIONS:-""}
-export 'HUBBLE_SHA'=${HUBBLE_SHA:-"186fa10"}
-export 'HUBBLE_GIT'=${HUBBLE_GIT:-https://github.com/cilium/hubble}
 NETNEXT="${NETNEXT:-false}"
 
 # VBoxguestAdditions installation
@@ -195,11 +193,11 @@ tar -xf "sonobuoy_${SONOBUOY_VERSION}_linux_amd64.tar.gz"
 sudo mv sonobuoy /usr/bin
 
 # Install hubble
-git clone ${HUBBLE_GIT}
-cd /tmp/hubble
-git reset --hard ${HUBBLE_SHA}
-make
-sudo make BINDIR=/usr/bin install
+cd /tmp
+wget "https://github.com/cilium/hubble/releases/download/v${HUBBLE_VERSION}/hubble-linux-amd64.tar.gz"
+wget "https://github.com/cilium/hubble/releases/download/v${HUBBLE_VERSION}/hubble-linux-amd64.tar.gz.sha256sum"
+sha256sum --check hubble-linux-amd64.tar.gz.sha256sum || exit 1
+sudo tar -xf "hubble-linux-amd64.tar.gz" -C /usr/bin hubble
 
 # Clean all downloaded packages
 sudo apt-get -y clean


### PR DESCRIPTION
Pull the latest istio images and install latest hubble v0.7.1 from binary artifacts
    
The hash cilium/hubble@186fa10 pinned in commit 570378f4f58b
has been included since hubble v0.7.0:
    
    $ git tag --contains=186fa10
    v0.7.0
    v0.7.1