### PR TITLE
provision: Bump Hubble to latest master

### DIFF
--- a/provision/env.bash
+++ b/provision/env.bash
@@ -3,7 +3,7 @@
 export GOLANG_VERSION="1.15.7"
 export ETCD_VERSION="v3.1.0"
 export CONTAINERD_VERSION="1.3.4"
-export HUBBLE_VERSION="0.7.1"
+export HUBBLE_VERSION="181982c0"
 export SONOBUOY_VERSION="0.14.2"
 export PROTOC_VERSION="3.12.4"
 export HOME_DIR=/home/vagrant

--- a/provision/pull-images.sh
+++ b/provision/pull-images.sh
@@ -56,7 +56,7 @@ if [ -z "${NAME_PREFIX}" ]; then
         quay.io/cilium/cilium-envoy:63de0bd958d05d82e2396125dcf6286d92464c56 \
         quay.io/cilium/cilium-builder:2021-01-20 \
         quay.io/cilium/cilium-runtime:2021-01-20 \
-        quay.io/cilium/hubble:v${HUBBLE_VERSION} \
+        quay.io/cilium/hubble:v0.7.1 \
         quay.io/cilium/net-test:v1.0.0 \
         quay.io/coreos/etcd:v3.4.7 \
 

--- a/provision/ubuntu/install.sh
+++ b/provision/ubuntu/install.sh
@@ -194,10 +194,11 @@ sudo mv sonobuoy /usr/bin
 
 # Install hubble
 cd /tmp
-wget "https://github.com/cilium/hubble/releases/download/v${HUBBLE_VERSION}/hubble-linux-amd64.tar.gz"
-wget "https://github.com/cilium/hubble/releases/download/v${HUBBLE_VERSION}/hubble-linux-amd64.tar.gz.sha256sum"
-sha256sum --check hubble-linux-amd64.tar.gz.sha256sum || exit 1
-sudo tar -xf "hubble-linux-amd64.tar.gz" -C /usr/bin hubble
+git clone https://github.com/cilium/hubble
+cd hubble
+git checkout "${HUBBLE_VERSION}"
+make
+sudo make install BINDIR=/usr/bin
 
 # Clean all downloaded packages
 sudo apt-get -y clean


### PR DESCRIPTION
This pulls in the lastest master version of the Hubble CLI. This is
needed to test the API changes to embedded Hubble in Cilium master,
specifcially cilium/cilium#14785

Ref: https://github.com/cilium/cilium/pull/14923

The pulled docker image remains at the released 0.7.1 version, as this
is what the Cilium master Dockerfile pulls in.


Signed-off-by: Sebastian Wicki <sebastian@isovalent.com>