### PR TITLE
Bump kernel 4.19 package

### DIFF
--- a/cilium-ubuntu-4.19.json
+++ b/cilium-ubuntu-4.19.json
@@ -93,7 +93,7 @@
       ]
     },{
       "type": "shell",
-      "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}' 041957 201907031234",
+      "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}' 0419177 202102231538",
       "expect_disconnect": true,
       "scripts": [
           "provision/ubuntu/kernel.sh"

--- a/provision/ubuntu/kernel.sh
+++ b/provision/ubuntu/kernel.sh
@@ -15,11 +15,16 @@ micro=$(echo ${canonicalString:4} | sed 's/^0*//')
 
 echo $major.$minor.$micro
 
-wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v$major.$minor.$micro/linux-headers-$major.$minor.$micro-$canonicalString-generic_$major.$minor.$micro-$canonicalString.${timestamp}_amd64.deb
-wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v$major.$minor.$micro/linux-headers-$major.$minor.$micro-${canonicalString}_$major.$minor.$micro-${canonicalString}.${timestamp}_all.deb
-wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v$major.$minor.$micro/linux-image-$major.$minor.$micro-$canonicalString-generic_$major.$minor.$micro-$canonicalString.${timestamp}_amd64.deb
-wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v$major.$minor.$micro/linux-image-unsigned-$major.$minor.$micro-$canonicalString-generic_$major.$minor.$micro-$canonicalString.${timestamp}_amd64.deb
-wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v$major.$minor.$micro/linux-modules-$major.$minor.$micro-$canonicalString-generic_$major.$minor.$micro-$canonicalString.${timestamp}_amd64.deb
+sub=""
+if [ "$minor" == "19" ] ; then
+	# kernel 4.19 debs are stored in an arch-specific sub-directory
+	subdir="amd64/"
+fi
+wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v$major.$minor.$micro/${subdir}linux-headers-$major.$minor.$micro-$canonicalString-generic_$major.$minor.$micro-$canonicalString.${timestamp}_amd64.deb
+wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v$major.$minor.$micro/${subdir}linux-headers-$major.$minor.$micro-${canonicalString}_$major.$minor.$micro-${canonicalString}.${timestamp}_all.deb
+wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v$major.$minor.$micro/${subdir}linux-image-$major.$minor.$micro-$canonicalString-generic_$major.$minor.$micro-$canonicalString.${timestamp}_amd64.deb
+wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v$major.$minor.$micro/${subdir}linux-image-unsigned-$major.$minor.$micro-$canonicalString-generic_$major.$minor.$micro-$canonicalString.${timestamp}_amd64.deb
+wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v$major.$minor.$micro/${subdir}linux-modules-$major.$minor.$micro-$canonicalString-generic_$major.$minor.$micro-$canonicalString.${timestamp}_amd64.deb
 
 dpkg -i *modules*.deb
 dpkg -i *.deb


### PR DESCRIPTION
It seems, the 4.19 kernel version we currently use (4.19.57) is no
longer available from https://kernel.ubuntu.com/~kernel-ppa/mainline
leading to the 4.19 image being built without a 4.19 kernel and using
the default 4.15 kernel. This breaks CI tests relying on 4.19+ features
(such as BPF NodePort). Thus bump to the latest 4.19 micro release
4.19.177.