### PR TITLE
Bump kernel 4.9 package

### DIFF
--- a/provision/ubuntu/kernel.sh
+++ b/provision/ubuntu/kernel.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 
-# This script installs kernel 4.9.212 and when it finished sets the installed
+set -e
+
+# This script installs kernel 4.9.258 and when it finished sets the installed
 # kernel as default in the grub.
 
 mkdir /tmp/deb
 cd /tmp/deb
 
-canonicalString=${1:-0409212}
-timestamp=${2:-202001300045}
+canonicalString=${1:-0409258}
+timestamp=${2:-202102231505}
 
 major=$(echo ${canonicalString:0:2} | sed 's/^0*//')
 minor=$(echo ${canonicalString:2:2} | sed 's/^0*//')
@@ -15,18 +17,19 @@ micro=$(echo ${canonicalString:4} | sed 's/^0*//')
 
 echo $major.$minor.$micro
 
-sub=""
 if [ "$minor" == "19" ] ; then
-	# kernel 4.19 debs are stored in an arch-specific sub-directory
-	subdir="amd64/"
-fi
-wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v$major.$minor.$micro/${subdir}linux-headers-$major.$minor.$micro-$canonicalString-generic_$major.$minor.$micro-$canonicalString.${timestamp}_amd64.deb
-wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v$major.$minor.$micro/${subdir}linux-headers-$major.$minor.$micro-${canonicalString}_$major.$minor.$micro-${canonicalString}.${timestamp}_all.deb
-wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v$major.$minor.$micro/${subdir}linux-image-$major.$minor.$micro-$canonicalString-generic_$major.$minor.$micro-$canonicalString.${timestamp}_amd64.deb
-wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v$major.$minor.$micro/${subdir}linux-image-unsigned-$major.$minor.$micro-$canonicalString-generic_$major.$minor.$micro-$canonicalString.${timestamp}_amd64.deb
-wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v$major.$minor.$micro/${subdir}linux-modules-$major.$minor.$micro-$canonicalString-generic_$major.$minor.$micro-$canonicalString.${timestamp}_amd64.deb
+	# kernel 4.19 debs have the -unsigned suffix
+	imgsuffix="-unsigned"
 
-dpkg -i *modules*.deb
+	# module deb is only provided for 4.19 kernels
+	wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v$major.$minor.$micro/amd64/linux-modules-$major.$minor.$micro-$canonicalString-generic_$major.$minor.$micro-$canonicalString.${timestamp}_amd64.deb
+	dpkg -i *modules*.deb
+fi
+
+wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v$major.$minor.$micro/amd64/linux-headers-$major.$minor.$micro-$canonicalString-generic_$major.$minor.$micro-$canonicalString.${timestamp}_amd64.deb
+wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v$major.$minor.$micro/amd64/linux-headers-$major.$minor.$micro-${canonicalString}_$major.$minor.$micro-${canonicalString}.${timestamp}_all.deb
+wget https://kernel.ubuntu.com/~kernel-ppa/mainline/v$major.$minor.$micro/amd64/linux-image${imgsuffix}-$major.$minor.$micro-$canonicalString-generic_$major.$minor.$micro-$canonicalString.${timestamp}_amd64.deb
+
 dpkg -i *.deb
 
 KERNEL="$major.$minor"


### PR DESCRIPTION
Like the 4.19 kernel package (see #256), the 4.9 kernel version
(4.9.212) is no longer available from https://kernel.ubuntu.com/~kernel-ppa/mainline
leading to the 4.9 image being built without a 4.9 kernel and using
the default 4.15 kernel. This breaks 4.9 specific CI tests  Thus bump to
the latest 4.9 patch release 4.9.258.

Also make sure we catch any errors in the kernel provisioning script, so
it should be easier to detect these cases during image build.