### PR TITLE
provision: Fix ownership of /home/vagrant

### DIFF
--- a/cilium-ubuntu-4.19.json
+++ b/cilium-ubuntu-4.19.json
@@ -119,7 +119,8 @@
           "provision/registry.sh",
           "provision/ubuntu/crio.sh",
           "provision/ubuntu/containerd.sh",
-          "provision/pull-images.sh"
+          "provision/pull-images.sh",
+          "provision/fix-home-ownership.sh"
       ]
     }
   ],

--- a/cilium-ubuntu-next.json
+++ b/cilium-ubuntu-next.json
@@ -125,7 +125,8 @@
           "provision/golang.sh",
           "provision/swap.sh",
           "provision/registry.sh",
-          "provision/pull-images.sh"
+          "provision/pull-images.sh",
+          "provision/fix-home-ownership.sh"
       ]
     }
   ],

--- a/cilium-ubuntu.json
+++ b/cilium-ubuntu.json
@@ -119,7 +119,8 @@
           "provision/registry.sh",
           "provision/ubuntu/crio.sh",
           "provision/ubuntu/containerd.sh",
-          "provision/pull-images.sh"
+          "provision/pull-images.sh",
+          "provision/fix-home-ownership.sh"
       ]
     }
   ],

--- a/provision/fix-home-ownership.sh
+++ b/provision/fix-home-ownership.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+source "${ENV_FILEPATH}"
+
+set -e
+
+# Provisioning scripts run as root, causing files in the vagrant user's home
+# directory to be owned by root, not vagrant. As a last step, fix the ownership
+# of all files.
+chown -R vagrant:vagrant "${HOME_DIR}"

--- a/provision/vagrant.sh
+++ b/provision/vagrant.sh
@@ -16,7 +16,6 @@ else
     echo "Cannot download vagrant public key";
     exit 1;
 fi
-chown -R vagrant "${HOME_DIR}/.ssh";
 chmod -R go-rwsx "${HOME_DIR}/.ssh";
 
 echo 'vagrant ALL=(ALL) NOPASSWD:ALL' >/etc/sudoers.d/99_vagrant


### PR DESCRIPTION
Before this PR, many files and directories are owned by root, meaning
that the vagrant user could not create or update files.

This PR adds a final step to fix the ownership.

Signed-off-by: Tom Payne <tom@isovalent.com>