### PR TITLE
Fix .ssh ownership for 5.4 box

### DIFF
--- a/cilium-ubuntu-5.4.json
+++ b/cilium-ubuntu-5.4.json
@@ -119,7 +119,8 @@
           "provision/registry.sh",
           "provision/ubuntu/crio.sh",
           "provision/ubuntu/containerd.sh",
-          "provision/pull-images.sh"
+          "provision/pull-images.sh",
+          "provision/fix-home-ownership.sh"
       ]
     }
   ],


### PR DESCRIPTION
Because https://github.com/cilium/packer-ci-build/pull/263 was not rebased to include https://github.com/cilium/packer-ci-build/pull/262 it broke ownerships for `.ssh` in the new 5.4 box.

Fixes: https://github.com/cilium/packer-ci-build/pull/263