### PR TITLE
provision: Add cilium-builder back to pre-pulled images

### DIFF
--- a/provision/pull-images.sh
+++ b/provision/pull-images.sh
@@ -53,6 +53,7 @@ if [ -z "${NAME_PREFIX}" ]; then
         gcr.io/google-samples/gb-frontend:v6 \
         gcr.io/google_samples/gb-redis-follower:v2 \
         quay.io/cilium/cilium-envoy:63de0bd958d05d82e2396125dcf6286d92464c56 \
+        quay.io/cilium/cilium-builder:3203db544891bf8360d97085ecce89282f04c78d \
         quay.io/cilium/kube-wireguarder:0.0.4 \
         quay.io/cilium/net-test:v1.0.0 \
         quay.io/coreos/etcd:v3.4.7 \


### PR DESCRIPTION
https://github.com/cilium/packer-ci-build/pull/254 removes the `cilium-{runtime,builder}` images from the list of pre-pulled images. The `cilium-builder` image is however still used by [K8sVerifier](https://github.com/cilium/cilium/blob/v1.10.0-rc0/test/k8sT/manifests/test-verifier.yaml) in Cilium's CI tests.

This pull request adds `cilium-builder` back, with the new tag from https://github.com/cilium/cilium/pull/15790.