### PR TITLE
Bump kernel 4.19 package

### DIFF
--- a/cilium-ubuntu-4.19.json
+++ b/cilium-ubuntu-4.19.json
@@ -93,7 +93,7 @@
       ]
     },{
       "type": "shell",
-      "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}' 0419177 202102231538",
+      "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}' 0419190 202105070933",
       "expect_disconnect": true,
       "scripts": [
           "provision/ubuntu/kernel.sh"


### PR DESCRIPTION
The 4.19 kernel version we currently use (4.19.177) is no longer available from the repository, leading to build failures for the image.

Looking at https://kernel.ubuntu.com/~kernel-ppa/mainline, it seems that versions where the patch version is not a multiple of five are removed after some time.

Bump to the latest 4.19 patch release 4.19.190, which should hopefully remain available for longer.
