### PR TITLE
provision: Bump 4.9 kernel packages

### DIFF
--- a/provision/ubuntu/kernel.sh
+++ b/provision/ubuntu/kernel.sh
@@ -8,8 +8,8 @@ set -e
 mkdir /tmp/deb
 cd /tmp/deb
 
-canonicalString=${1:-0409258}
-timestamp=${2:-202102231505}
+canonicalString=${1:-0409270}
+timestamp=${2:-202105261032}
 subdir="amd64/"
 
 major=$(echo ${canonicalString:0:2} | sed 's/^0*//')


### PR DESCRIPTION
The packages for 4.9.258 are not available for download anymore, so bump to 4.9.270, which should stay longer (as it's a multiple of 5). See b956b07 ("Bump kernel 4.19 package") for details.

With that change, all three kernels for which we use packages are now on multiples of 5.