### PR TITLE
Revert "provision: install Cilium CLI"

### DIFF
--- a/provision/ubuntu/install.sh
+++ b/provision/ubuntu/install.sh
@@ -203,13 +203,6 @@ git checkout "${HUBBLE_VERSION}"
 make
 sudo make install BINDIR=/usr/bin
 
-# Install Cilium CLI
-cd /tmp/
-curl -L --remote-name-all https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-${ARCH}.tar.gz{,.sha256sum}
-sha256sum --check --strict cilium-linux-${ARCH}.tar.gz.sha256sum
-sudo tar xzfC cilium-linux-${ARCH}.tar.gz /usr/local/bin
-rm cilium-linux-${ARCH}.tar.gz{,.sha256sum}
-
 # Clean all downloaded packages
 sudo apt-get -y clean
 sudo apt-get -y autoclean


### PR DESCRIPTION
This reverts commit 430530bfee5a9738decfd85912491101357c4ce4.

We can't simply install the cilium CLI in the VMs for Runtime tests and development because, in those VMs, Cilium runs as a service. That means `cilium` already executes the CLI for the Cilium agent in those VMs.