### PR TITLE
provision: Install `ipset` binary

### DIFF
--- a/provision/ubuntu/install.sh
+++ b/provision/ubuntu/install.sh
@@ -66,7 +66,7 @@ sudo apt-get install -y --allow-downgrades \
     po-debconf autoconf autopoint moreutils \
     libseccomp2 libenchant1c2a ninja-build \
     golang-cfssl ntp \
-    wireguard
+    wireguard ipset
 
 # Install nodejs and npm, needed for the cilium rtd sphinx theme
 curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add -


### PR DESCRIPTION
The `ipset` binary is required in the VMs because of https://github.com/cilium/cilium/pull/16603 when Cilium is running as a service (e.g., for development VMs and for Runtime tests).