### PR TITLE
provision: add patch to fix cpumask regression breaking kubelet

### DIFF
--- a/bpf-next-patches/0001-cpumask-Omit-terminating-null-byte-in-cpumap_print_-.patch
+++ b/bpf-next-patches/0001-cpumask-Omit-terminating-null-byte-in-cpumap_print_-.patch
@@ -1,0 +1,67 @@
+From c86a2d9058c5a4a05d20ef89e699b7a6b2c89da6 Mon Sep 17 00:00:00 2001
+From: Tobias Klauser <tklauser@distanz.ch>
+Date: Fri, 17 Sep 2021 00:27:05 +0200
+Subject: [PATCH] cpumask: Omit terminating null byte in
+ cpumap_print_{list,bitmask}_to_buf
+
+The changes in the patch series [1] introduced a terminating null byte
+when reading from cpulist or cpumap sysfs files, for example:
+
+  $ xxd /sys/devices/system/node/node0/cpulist
+  00000000: 302d 310a 00                             0-1..
+
+Before this change, the output looked as follows:
+
+  $ xxd /sys/devices/system/node/node0/cpulist
+  00000000: 302d 310a                                0-1.
+
+Fix this regression by excluding the terminating null byte from the
+returned length in cpumap_print_list_to_buf and
+cpumap_print_bitmask_to_buf.
+
+[1] https://lore.kernel.org/all/20210806110251.560-1-song.bao.hua@hisilicon.com/
+
+Fixes: 1fae562983ca ("cpumask: introduce cpumap_print_list/bitmask_to_buf to support large bitmask and list")
+Acked-by: Barry Song <song.bao.hua@hisilicon.com>
+Acked-by: Yury Norov <yury.norov@gmail.com>
+Signed-off-by: Tobias Klauser <tklauser@distanz.ch>
+Link: https://lore.kernel.org/r/20210916222705.13554-1-tklauser@distanz.ch
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ include/linux/cpumask.h | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/include/linux/cpumask.h b/include/linux/cpumask.h
+index 5d4d07a9e1ed..1e7399fc69c0 100644
+--- a/include/linux/cpumask.h
++++ b/include/linux/cpumask.h
+@@ -996,14 +996,15 @@ cpumap_print_to_pagebuf(bool list, char *buf, const struct cpumask *mask)
+  * cpumask; Typically used by bin_attribute to export cpumask bitmask
+  * ABI.
+  *
+- * Returns the length of how many bytes have been copied.
++ * Returns the length of how many bytes have been copied, excluding
++ * terminating '\0'.
+  */
+ static inline ssize_t
+ cpumap_print_bitmask_to_buf(char *buf, const struct cpumask *mask,
+ 		loff_t off, size_t count)
+ {
+ 	return bitmap_print_bitmask_to_buf(buf, cpumask_bits(mask),
+-				   nr_cpu_ids, off, count);
++				   nr_cpu_ids, off, count) - 1;
+ }
+ 
+ /**
+@@ -1018,7 +1019,7 @@ cpumap_print_list_to_buf(char *buf, const struct cpumask *mask,
+ 		loff_t off, size_t count)
+ {
+ 	return bitmap_print_list_to_buf(buf, cpumask_bits(mask),
+-				   nr_cpu_ids, off, count);
++				   nr_cpu_ids, off, count) - 1;
+ }
+ 
+ #if NR_CPUS <= BITS_PER_LONG
+-- 
+2.33.0
+

--- a/cilium-ubuntu-next.json
+++ b/cilium-ubuntu-next.json
@@ -85,6 +85,10 @@
   ],
   "provisioners": [
     {
+      "type": "file",
+      "source": "bpf-next-patches/",
+      "destination": "/tmp"
+    },{
       "type": "shell",
       "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
       "expect_disconnect": true,

--- a/provision/ubuntu/kernel-next.sh
+++ b/provision/ubuntu/kernel-next.sh
@@ -27,6 +27,9 @@ rm -rf pahole
 
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/
 
+# Apply local patches
+git apply < /tmp/*.patch
+
 # Build kernel
 cp /boot/config-`uname -r` .config
 make olddefconfig && make prepare


### PR DESCRIPTION
Add a patch [1] to the bpf-next kernel build which fixes a regression
which causes kubelet to error out on startup.

See [2] and following comments for details.

[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=c86a2d9058c5a4a05d20ef89e699b7a6b2c89da6
[2] https://github.com/cilium/cilium/pull/17394#issuecomment-920902042

Suggested-by: Daniel Borkmann <daniel@iogearbox.net>
Signed-off-by: Tobias Klauser <tobias@cilium.io>