### PR TITLE
provision/ubuntu: correctly set LIBDIR when installing libbpf

### DIFF
--- a/provision/ubuntu/install.sh
+++ b/provision/ubuntu/install.sh
@@ -134,7 +134,7 @@ make -j "$(getconf _NPROCESSORS_ONLN)"
 # By default, libbpf.so is installed to /usr/lib64 which isn't in LD_LIBRARY_PATH on Ubuntu.
 # Overriding LIBDIR in addition to setting PREFIX seems to be needed due to the structure of
 # libbpf's Makefile.
-PREFIX="/usr" LIBDIR=/usr/lib/x86_64-linux-gnu sudo make install
+sudo PREFIX="/usr" LIBDIR="/usr/lib/x86_64-linux-gnu" make install
 sudo ldconfig
 
 cd /tmp


### PR DESCRIPTION
By default, sudo does not preserve environment variables, thus set them
explicitly as part of the commend invoked in `sudo`. As a result, the
change made in commit a5e6bb35d47e ("provision/ubuntu: install
libbpf.so to a directory in LD_LIBRARY_PATH") did not result in
libbpf.so being installed in the correct location. Fix the install
command to now do so.