### PR TITLE
Revert bpf-next commit breaking bpf loading of Cilium's bpf_overlay.o

### DIFF
--- a/bpf-next-patches/0001-Revert-bpf-Support-8-byte-scalar-spill-and-refill.patch
+++ b/bpf-next-patches/0001-Revert-bpf-Support-8-byte-scalar-spill-and-refill.patch
@@ -1,0 +1,170 @@
+From 62702ddfdaa8d41454ab83d827dad367b9031d7f Mon Sep 17 00:00:00 2001
+From: Tobias Klauser <tobias@cilium.io>
+Date: Mon, 11 Oct 2021 11:23:48 +0200
+Subject: [PATCH] Revert "bpf: Support <8-byte scalar spill and refill"
+
+This reverts commit 354e8f1970f821d4952458f77b1ab6c3eb24d530.
+
+Reason for revert: currently breaks loading of Cilium's bpf_overlay.o
+using bpf-next kernel.
+
+Signed-off-by: Tobias Klauser <tobias@cilium.io>
+---
+ kernel/bpf/verifier.c | 67 ++++++++++---------------------------------
+ 1 file changed, 15 insertions(+), 52 deletions(-)
+
+diff --git a/kernel/bpf/verifier.c b/kernel/bpf/verifier.c
+index 20900a1bac12..979b0e0651c3 100644
+--- a/kernel/bpf/verifier.c
++++ b/kernel/bpf/verifier.c
+@@ -620,12 +620,6 @@ static bool is_spilled_reg(const struct bpf_stack_state *stack)
+ 	return stack->slot_type[BPF_REG_SIZE - 1] == STACK_SPILL;
+ }
+ 
+-static void scrub_spilled_slot(u8 *stype)
+-{
+-	if (*stype != STACK_INVALID)
+-		*stype = STACK_MISC;
+-}
+-
+ static void print_verifier_state(struct bpf_verifier_env *env,
+ 				 const struct bpf_func_state *state)
+ {
+@@ -2789,21 +2783,15 @@ static bool __is_pointer_value(bool allow_ptr_leaks,
+ }
+ 
+ static void save_register_state(struct bpf_func_state *state,
+-				int spi, struct bpf_reg_state *reg,
+-				int size)
++				int spi, struct bpf_reg_state *reg)
+ {
+ 	int i;
+ 
+ 	state->stack[spi].spilled_ptr = *reg;
+-	if (size == BPF_REG_SIZE)
+-		state->stack[spi].spilled_ptr.live |= REG_LIVE_WRITTEN;
++	state->stack[spi].spilled_ptr.live |= REG_LIVE_WRITTEN;
+ 
+-	for (i = BPF_REG_SIZE; i > BPF_REG_SIZE - size; i--)
+-		state->stack[spi].slot_type[i - 1] = STACK_SPILL;
+-
+-	/* size < 8 bytes spill */
+-	for (; i; i--)
+-		scrub_spilled_slot(&state->stack[spi].slot_type[i - 1]);
++	for (i = 0; i < BPF_REG_SIZE; i++)
++		state->stack[spi].slot_type[i] = STACK_SPILL;
+ }
+ 
+ /* check_stack_{read,write}_fixed_off functions track spill/fill of registers,
+@@ -2850,7 +2838,7 @@ static int check_stack_write_fixed_off(struct bpf_verifier_env *env,
+ 			env->insn_aux_data[insn_idx].sanitize_stack_spill = true;
+ 	}
+ 
+-	if (reg && !(off % BPF_REG_SIZE) && register_is_bounded(reg) &&
++	if (reg && size == BPF_REG_SIZE && register_is_bounded(reg) &&
+ 	    !register_is_null(reg) && env->bpf_capable) {
+ 		if (dst_reg != BPF_REG_FP) {
+ 			/* The backtracking logic can only recognize explicit
+@@ -2863,7 +2851,7 @@ static int check_stack_write_fixed_off(struct bpf_verifier_env *env,
+ 			if (err)
+ 				return err;
+ 		}
+-		save_register_state(state, spi, reg, size);
++		save_register_state(state, spi, reg);
+ 	} else if (reg && is_spillable_regtype(reg->type)) {
+ 		/* register containing pointer is being spilled into stack */
+ 		if (size != BPF_REG_SIZE) {
+@@ -2875,7 +2863,7 @@ static int check_stack_write_fixed_off(struct bpf_verifier_env *env,
+ 			verbose(env, "cannot spill pointers to stack into stack frame of the caller\n");
+ 			return -EINVAL;
+ 		}
+-		save_register_state(state, spi, reg, size);
++		save_register_state(state, spi, reg);
+ 	} else {
+ 		u8 type = STACK_MISC;
+ 
+@@ -2884,7 +2872,7 @@ static int check_stack_write_fixed_off(struct bpf_verifier_env *env,
+ 		/* Mark slots as STACK_MISC if they belonged to spilled ptr. */
+ 		if (is_spilled_reg(&state->stack[spi]))
+ 			for (i = 0; i < BPF_REG_SIZE; i++)
+-				scrub_spilled_slot(&state->stack[spi].slot_type[i]);
++				state->stack[spi].slot_type[i] = STACK_MISC;
+ 
+ 		/* only mark the slot as written if all 8 bytes were written
+ 		 * otherwise read propagation may incorrectly stop too soon
+@@ -3087,50 +3075,23 @@ static int check_stack_read_fixed_off(struct bpf_verifier_env *env,
+ 	struct bpf_func_state *state = vstate->frame[vstate->curframe];
+ 	int i, slot = -off - 1, spi = slot / BPF_REG_SIZE;
+ 	struct bpf_reg_state *reg;
+-	u8 *stype, type;
++	u8 *stype;
+ 
+ 	stype = reg_state->stack[spi].slot_type;
+ 	reg = &reg_state->stack[spi].spilled_ptr;
+ 
+ 	if (is_spilled_reg(&reg_state->stack[spi])) {
+ 		if (size != BPF_REG_SIZE) {
+-			u8 scalar_size = 0;
+-
+ 			if (reg->type != SCALAR_VALUE) {
+ 				verbose_linfo(env, env->insn_idx, "; ");
+ 				verbose(env, "invalid size of register fill\n");
+ 				return -EACCES;
+ 			}
+-
+-			mark_reg_read(env, reg, reg->parent, REG_LIVE_READ64);
+-			if (dst_regno < 0)
+-				return 0;
+-
+-			for (i = BPF_REG_SIZE; i > 0 && stype[i - 1] == STACK_SPILL; i--)
+-				scalar_size++;
+-
+-			if (!(off % BPF_REG_SIZE) && size == scalar_size) {
+-				/* The earlier check_reg_arg() has decided the
+-				 * subreg_def for this insn.  Save it first.
+-				 */
+-				s32 subreg_def = state->regs[dst_regno].subreg_def;
+-
+-				state->regs[dst_regno] = *reg;
+-				state->regs[dst_regno].subreg_def = subreg_def;
+-			} else {
+-				for (i = 0; i < size; i++) {
+-					type = stype[(slot - i) % BPF_REG_SIZE];
+-					if (type == STACK_SPILL)
+-						continue;
+-					if (type == STACK_MISC)
+-						continue;
+-					verbose(env, "invalid read from stack off %d+%d size %d\n",
+-						off, i, size);
+-					return -EACCES;
+-				}
++			if (dst_regno >= 0) {
+ 				mark_reg_unknown(env, state->regs, dst_regno);
++				state->regs[dst_regno].live |= REG_LIVE_WRITTEN;
+ 			}
+-			state->regs[dst_regno].live |= REG_LIVE_WRITTEN;
++			mark_reg_read(env, reg, reg->parent, REG_LIVE_READ64);
+ 			return 0;
+ 		}
+ 		for (i = 1; i < BPF_REG_SIZE; i++) {
+@@ -3161,6 +3122,8 @@ static int check_stack_read_fixed_off(struct bpf_verifier_env *env,
+ 		}
+ 		mark_reg_read(env, reg, reg->parent, REG_LIVE_READ64);
+ 	} else {
++		u8 type;
++
+ 		for (i = 0; i < size; i++) {
+ 			type = stype[(slot - i) % BPF_REG_SIZE];
+ 			if (type == STACK_MISC)
+@@ -4718,7 +4681,7 @@ static int check_stack_range_initialized(
+ 			if (clobber) {
+ 				__mark_reg_unknown(env, &state->stack[spi].spilled_ptr);
+ 				for (j = 0; j < BPF_REG_SIZE; j++)
+-					scrub_spilled_slot(&state->stack[spi].slot_type[j]);
++					state->stack[spi].slot_type[j] = STACK_MISC;
+ 			}
+ 			goto mark;
+ 		}
+-- 
+2.33.0
+

--- a/provision/env.bash
+++ b/provision/env.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export GOLANG_VERSION="1.17.1"
+export GOLANG_VERSION="1.17.2"
 export ETCD_VERSION="v3.1.0"
 export CONTAINERD_VERSION="1.3.4"
 export HUBBLE_VERSION="0.8.1"

--- a/provision/env.bash
+++ b/provision/env.bash
@@ -3,7 +3,7 @@
 export GOLANG_VERSION="1.17.2"
 export ETCD_VERSION="v3.1.0"
 export CONTAINERD_VERSION="1.3.4"
-export HUBBLE_VERSION="0.8.1"
+export HUBBLE_VERSION="0.8.2"
 export SONOBUOY_VERSION="0.14.2"
 export PROTOC_VERSION="3.12.4"
 export HOME_DIR=/home/vagrant

--- a/provision/ubuntu/kernel-next.sh
+++ b/provision/ubuntu/kernel-next.sh
@@ -28,7 +28,7 @@ rm -rf pahole
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/
 
 # Apply local patches
-git apply < /tmp/*.patch
+git apply /tmp/*.patch
 
 # Build kernel
 cp /boot/config-`uname -r` .config


### PR DESCRIPTION
Daniel confirmed that the upstream patch [`354e8f1970f8 ("bpf: Support <8-byte scalar spill and refill")`](https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git/commit/kernel/bpf/verifier.c?h=for-next&id=354e8f1970f821d4952458f77b1ab6c3eb24d530) breaks loading of Cilium's `bpf_overlay.o` when `tunnel=vxlan`, see https://jenkins.cilium.io/job/Cilium-PR-Runtime-net-next/304. Revert that patch for now until a proper fix is upstreamed.

While at it also update Go to 1.17.2 and Hubble CLI to 0.8.2.