### PR TITLE
Update to kernel 4.19.210

### DIFF
--- a/cilium-ubuntu-4.19.json
+++ b/cilium-ubuntu-4.19.json
@@ -91,7 +91,7 @@
       ]
     },{
       "type": "shell",
-      "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}' 0419190 202105070933",
+      "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}' 0419210 202110091331",
       "expect_disconnect": true,
       "scripts": [
           "provision/ubuntu/kernel.sh"


### PR DESCRIPTION
A new complexity issue was reported in cilium/cilium with default configuration on kernel 4.19.208+ (cf. https://github.com/cilium/cilium/issues/17647). We can update our 4.19 image to try and catch it if it affects Cilium's master.

We update to a round number because other packages are deleted from upstream faster.