### PR TITLE
provision: Commit bpf-next patches

### DIFF
--- a/provision/ubuntu/kernel-next.sh
+++ b/provision/ubuntu/kernel-next.sh
@@ -28,7 +28,7 @@ rm -rf pahole
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/
 
 # Apply local patches
-git apply /tmp/*.patch
+git am /tmp/*.patch
 
 # Build kernel
 cp /boot/config-`uname -r` .config


### PR DESCRIPTION
Commit the bpf-next patches instead of just applying changes, to avoid the `-dirty` suffix on the kernel image's version string.