### PR TITLE
provision: Fix warning for guest additions

### DIFF
--- a/cilium-ubuntu-next.json
+++ b/cilium-ubuntu-next.json
@@ -99,7 +99,6 @@
       "type": "shell",
       "environment_vars": [
         "ENV_FILEPATH=/tmp/env.bash",
-        "GUESTADDITIONS=https://download.virtualbox.org/virtualbox/5.2.20/VBoxGuestAdditions_5.2.20.iso",
         "NETNEXT=true"
       ],
       "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'",


### PR DESCRIPTION
The net-next image provisioning currently has the following warning message:

    k8s1+: Checking for guest additions in VM...
    k8s1+: The guest additions on this VM do not match the installed version of
    k8s1+: VirtualBox! In most cases this is fine, but in rare cases it can
    k8s1+: prevent things such as shared folders from working properly. If you see
    k8s1+: shared folder errors, please make sure the guest additions within the
    k8s1+: virtual machine match the version of VirtualBox you have installed on
    k8s1+: your host and reload your VM.
    k8s1+:
    k8s1+: Guest Additions Version: 5.2.20
    k8s1+: VirtualBox Version: 6.0