### PR TITLE
Fix VM images to pass Cilium's tests

### DIFF
--- a/cilium-ubuntu-4.19.json
+++ b/cilium-ubuntu-4.19.json
@@ -36,8 +36,8 @@
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
-      "ssh_timeout": "20m",
-      "ssh_handshake_attempts": "200",
+      "ssh_timeout": "15m",
+      "ssh_handshake_attempts": "100",
       "type": "virtualbox-iso",
       "vboxmanage": [
         [

--- a/cilium-ubuntu-5.4.json
+++ b/cilium-ubuntu-5.4.json
@@ -37,8 +37,8 @@
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "ssh_timeout": "20m",
-      "ssh_handshake_attempts": "200",
+      "ssh_timeout": "15m",
+      "ssh_handshake_attempts": "100",
       "type": "virtualbox-iso",
       "vboxmanage": [
         [

--- a/cilium-ubuntu-next.json
+++ b/cilium-ubuntu-next.json
@@ -37,8 +37,8 @@
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
-      "ssh_timeout": "20m",
-      "ssh_handshake_attempts": "200",
+      "ssh_timeout": "15m",
+      "ssh_handshake_attempts": "100",
       "type": "virtualbox-iso",
       "vboxmanage": [
         [

--- a/cilium-ubuntu.json
+++ b/cilium-ubuntu.json
@@ -36,8 +36,8 @@
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_username": "vagrant",
-      "ssh_timeout": "20m",
-      "ssh_handshake_attempts": "200",
+      "ssh_timeout": "15m",
+      "ssh_handshake_attempts": "100",
       "type": "virtualbox-iso",
       "vboxmanage": [
         [

--- a/provision/ubuntu/install.sh
+++ b/provision/ubuntu/install.sh
@@ -25,6 +25,7 @@ fi
 
 mkdir -p /tmp/vbox;
 mount -o loop ${HOME_DIR}/$ISO /tmp/vbox;
+modprobe -r vboxguest || [[ "$NETNEXT" == "false" ]]
 sh /tmp/vbox/VBoxLinuxAdditions.run
 umount /tmp/vbox;
 rm -rf /tmp/vbox;

--- a/provision/ubuntu/install.sh
+++ b/provision/ubuntu/install.sh
@@ -7,7 +7,7 @@ export 'IPROUTE_BRANCH'=${IPROUTE_BRANCH:-"libbpf-static-data"}
 export 'IPROUTE_GIT'=${IPROUTE_GIT:-https://github.com/cilium/iproute2}
 export 'LIBBPF_GIT'=${LIBBPF_GIT:-https://github.com/cilium/libbpf}
 export 'GUESTADDITIONS'=${GUESTADDITIONS:-""}
-NETNEXT="${NETNEXT:-false}"
+export 'NETNEXT'="${NETNEXT:-false}"
 
 ARCH="amd64"
 
@@ -25,9 +25,7 @@ fi
 
 mkdir -p /tmp/vbox;
 mount -o loop ${HOME_DIR}/$ISO /tmp/vbox;
-sh /tmp/vbox/VBoxLinuxAdditions.run \
-    || echo "VBoxLinuxAdditions.run exited $? and is suppressed." \
-    "For more read https://www.virtualbox.org/ticket/12479";
+sh /tmp/vbox/VBoxLinuxAdditions.run
 umount /tmp/vbox;
 rm -rf /tmp/vbox;
 rm -f ${HOME_DIR}/*.iso;

--- a/provision/ubuntu/kernel-next.sh
+++ b/provision/ubuntu/kernel-next.sh
@@ -65,6 +65,7 @@ yes "" | make localyesconfig && make prepare
 ./scripts/config --enable CONFIG_DEBUG_INFO_BTF_MODULES
 ./scripts/config --disable CONFIG_SYSTEM_TRUSTED_KEYS
 ./scripts/config --disable CONFIG_SYSTEM_REVOCATION_KEYS
+./scripts/config --enable CONFIG_VIRTIO_NET
 # Needed by VirtualBox to load the Guest Additions.
 ./scripts/config --enable CONFIG_ISO9660_FS
 # Needed for Docker.
@@ -83,6 +84,61 @@ yes "" | make localyesconfig && make prepare
 ./scripts/config --module CONFIG_IP_NF_NAT
 ./scripts/config --module CONFIG_NF_NAT
 ./scripts/config --enable CONFIG_DM_THIN_PROVISIONING
+# Needed for Kubernetes.
+./scripts/config --module CONFIG_IP_NF_TARGET_REDIRECT
+./scripts/config --module CONFIG_NETFILTER_XT_MATCH_COMMENT
+# Needed for Cilium.
+./scripts/config --enable CONFIG_IP_NF_MANGLE
+./scripts/config --enable CONFIG_IP_NF_RAW
+./scripts/config --enable CONFIG_IP6_NF_IPTABLES
+./scripts/config --enable CONFIG_IP6_NF_FILTER
+./scripts/config --enable CONFIG_IP6_NF_MANGLE
+./scripts/config --enable CONFIG_IP6_NF_RAW
+./scripts/config --enable CONFIG_IP6_NF_NAT
+./scripts/config --enable CONFIG_IP6_NF_TARGET_MASQUERADE
+./scripts/config --module CONFIG_NETFILTER_XT_TARGET_TPROXY
+./scripts/config --module CONFIG_NETFILTER_XT_MATCH_MARK
+./scripts/config --module CONFIG_NETFILTER_XT_MATCH_SOCKET
+./scripts/config --module CONFIG_NETFILTER_XT_TARGET_CT
+./scripts/config --module CONFIG_IP_SET
+./scripts/config --module CONFIG_IP_SET_HASH_IP
+./scripts/config --module CONFIG_NETFILTER_XT_SET
+./scripts/config --module CONFIG_VXLAN
+./scripts/config --module CONFIG_GENEVE
+./scripts/config --module CONFIG_NET_SCH_FQ
+# Needed for Cilium's IPsec implementation.
+./scripts/config --enable CONFIG_XFRM
+./scripts/config --enable CONFIG_XFRM_OFFLOAD
+./scripts/config --enable CONFIG_XFRM_STATISTICS
+./scripts/config --module CONFIG_XFRM_ALGO
+./scripts/config --module CONFIG_XFRM_USER
+./scripts/config --module CONFIG_INET_ESP
+./scripts/config --module CONFIG_INET_IPCOMP
+./scripts/config --module CONFIG_INET_XFRM_TUNNEL
+./scripts/config --module CONFIG_INET_TUNNEL
+./scripts/config --module CONFIG_INET6_ESP
+./scripts/config --module CONFIG_INET6_IPCOMP
+./scripts/config --module CONFIG_INET6_XFRM_TUNNEL
+./scripts/config --module CONFIG_INET6_TUNNEL
+./scripts/config --module CONFIG_INET_XFRM_MODE_TUNNEL
+./scripts/config --module CONFIG_CRYPTO_AEAD
+./scripts/config --module CONFIG_CRYPTO_AEAD2
+./scripts/config --module CONFIG_CRYPTO_GCM
+./scripts/config --module CONFIG_CRYPTO_SEQIV
+./scripts/config --module CONFIG_CRYPTO_CBC
+./scripts/config --module CONFIG_CRYPTO_HMAC
+./scripts/config --module CONFIG_CRYPTO_SHA256
+./scripts/config --module CONFIG_CRYPTO_AES
+# Needed for Cilium's tests.
+./scripts/config --module CONFIG_NF_CT_NETLINK
+./scripts/config --module CONFIG_DUMMY
+./scripts/config --module CONFIG_BONDING
+./scripts/config --module CONFIG_VLAN_8021Q
+# Needed for NFS shared folders.
+./scripts/config --module CONFIG_NFS_FS
+./scripts/config --module CONFIG_NFS_V3
+./scripts/config --module CONFIG_NFSD
+./scripts/config --enable CONFIG_NFSD_V3
 
 yes "" | make config
 make -j$(nproc) deb-pkg

--- a/provision/ubuntu/kernel-next.sh
+++ b/provision/ubuntu/kernel-next.sh
@@ -76,7 +76,7 @@ yes "" | make localyesconfig && make prepare
 ./scripts/config --module CONFIG_NETFILTER_XT_MATCH_ADDRTYPE
 ./scripts/config --module CONFIG_NETFILTER_XT_MATCH_CONNTRACK
 ./scripts/config --module CONFIG_NETFILTER_XT_MATCH_IPVS
-./scripts/config --module CONFIG_NETFILTER_ADVANCED
+./scripts/config --enable CONFIG_NETFILTER_ADVANCED
 ./scripts/config --enable CONFIG_NF_CONNTRACK
 ./scripts/config --enable CONFIG_IP_VS
 ./scripts/config --module CONFIG_NETFILTER_XT_MARK

--- a/provision/ubuntu/kernel-next.sh
+++ b/provision/ubuntu/kernel-next.sh
@@ -84,6 +84,7 @@ yes "" | make localyesconfig && make prepare
 ./scripts/config --module CONFIG_NF_NAT
 ./scripts/config --enable CONFIG_DM_THIN_PROVISIONING
 
+yes "" | make config
 make -j$(nproc) deb-pkg
 cd ..
 # remove repo before installation to avoid "no space left on device" errors


### PR DESCRIPTION
In https://github.com/cilium/packer-ci-build/pull/289, the VM images were significantly changed to upgrade Ubuntu, but also to specialize the net-next kernel's config (https://github.com/cilium/packer-ci-build/commit/d1841cb1162ae91efbae11d5b9709ed880fdcc9c). The corresponding pull request in cilium/cilium,  https://github.com/cilium/cilium/pull/17761, uncovered many issues which are fixed in the present pull request.

The resulting net-next VM image was tested locally by replacing the usual Vagrant VM image with the newly-built image and running the full set of `K8s` and `Runtime` tests. A couple tests (e.g., `K8sIstio`) still fail, but they seem unrelated to kernel support, so maybe some other issue with running locally. In any case, we can always iterate fix further fixes later.

See commits for details.