### PR TITLE
Disable debug mode on AWS S3 upload

### DIFF
--- a/cilium-ubuntu-4.19.json
+++ b/cilium-ubuntu-4.19.json
@@ -115,7 +115,7 @@
     }, {
       "type": "shell-local",
       "inline": [
-        "/usr/bin/aws s3 cp cilium-ginkgo-ubuntu-4-19-{{user `NAME_PREFIX`}}{{user `BUILD_ID`}}.box s3://ciliumvagrantbaseboxes/ --debug"
+        "/usr/bin/aws s3 cp cilium-ginkgo-ubuntu-4-19-{{user `NAME_PREFIX`}}{{user `BUILD_ID`}}.box s3://ciliumvagrantbaseboxes/"
       ]
     }],[{
       "output": "cilium-ginkgo-ubuntu-4-19-{{user `NAME_PREFIX`}}{{user `BUILD_ID`}}.box",

--- a/cilium-ubuntu-5.4.json
+++ b/cilium-ubuntu-5.4.json
@@ -116,7 +116,7 @@
     }, {
       "type": "shell-local",
       "inline": [
-        "/usr/bin/aws s3 cp cilium-ginkgo-ubuntu-5-4-{{user `NAME_PREFIX`}}{{user `BUILD_ID`}}.box s3://ciliumvagrantbaseboxes/ --debug"
+        "/usr/bin/aws s3 cp cilium-ginkgo-ubuntu-5-4-{{user `NAME_PREFIX`}}{{user `BUILD_ID`}}.box s3://ciliumvagrantbaseboxes/"
       ]
     }],[{
       "output": "cilium-ginkgo-ubuntu-5-4-{{user `NAME_PREFIX`}}{{user `BUILD_ID`}}.box",

--- a/cilium-ubuntu.json
+++ b/cilium-ubuntu.json
@@ -115,7 +115,7 @@
     }, {
       "type": "shell-local",
       "inline": [
-        "/usr/bin/aws s3 cp cilium-ginkgo-ubuntu-{{user `NAME_PREFIX`}}{{user `BUILD_ID`}}.box s3://ciliumvagrantbaseboxes/ --debug"
+        "/usr/bin/aws s3 cp cilium-ginkgo-ubuntu-{{user `NAME_PREFIX`}}{{user `BUILD_ID`}}.box s3://ciliumvagrantbaseboxes/"
       ]
     }],[{
       "output": "cilium-ginkgo-ubuntu-{{user `NAME_PREFIX`}}{{user `BUILD_ID`}}.box",


### PR DESCRIPTION
Currently, the aws CLI used to upload the boxes on master builds are
invoked with `--debug` leading to the logs being flooded with lots of
AWS CLI debug log messages, see [1] for a recent example. This makes it
hard to analyze the logs for earlier interesting log messages, so
disable these debug logs.

[1] https://jenkins.cilium.io/view/Packer%20builds/job/Vagrant-Master-Boxes-Packer-Build-5.4/19/console