### PR TITLE
provision: Enable bpftool to dump JITed programs

### DIFF
--- a/provision/ubuntu/kernel-next-bpftool.sh
+++ b/provision/ubuntu/kernel-next-bpftool.sh
@@ -6,7 +6,7 @@ export 'KCONFIG'=${KCONFIG:-"config-`uname -r`"}
 
 sudo apt-get install -y --allow-downgrades \
     pkg-config bison flex build-essential gcc libssl-dev \
-    libelf-dev bc
+    libelf-dev bc libbfd-dev
 
 git clone --depth 1 git://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git $HOME/k
 cd $HOME/k


### PR DESCRIPTION
To dump JIted programs, bpftool needs the `libbfd-dev` dependency. That package is installed via another package at some time during provisioning, but after the bpftool compilation. As a result, the bpftool binary in the VMs is currently unable to dump the JITed programs.