### PR TITLE
bpf-next: Fix incorrect dead code elimination

### DIFF
--- a/cilium-ubuntu-next.json
+++ b/cilium-ubuntu-next.json
@@ -66,6 +66,10 @@
         "echo 'vagrant' | sudo -S resize2fs /dev/ubuntu-vg/ubuntu-lv"
       ]
     },{
+      "type": "file",
+      "source": "kernel-patches/",
+      "destination": "/tmp"
+    },{
       "type": "shell",
       "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
       "expect_disconnect": true,

--- a/kernel-patches/bpf-Fix-incorrect-state-pruning-for-8B-spill-fill.patch
+++ b/kernel-patches/bpf-Fix-incorrect-state-pruning-for-8B-spill-fill.patch
@@ -1,0 +1,88 @@
+From 345e004d023343d38088fdfea39688aa11e06ccf Mon Sep 17 00:00:00 2001
+From: Paul Chaignon <paul@isovalent.com>
+Date: Fri, 10 Dec 2021 00:46:31 +0100
+Subject: [PATCH] bpf: Fix incorrect state pruning for <8B spill/fill
+
+Commit 354e8f1970f8 ("bpf: Support <8-byte scalar spill and refill")
+introduced support in the verifier to track <8B spill/fills of scalars.
+The backtracking logic for the precision bit was however skipping
+spill/fills of less than 8B. That could cause state pruning to consider
+two states equivalent when they shouldn't be.
+
+As an example, consider the following bytecode snippet:
+
+  0:  r7 = r1
+  1:  call bpf_get_prandom_u32
+  2:  r6 = 2
+  3:  if r0 == 0 goto pc+1
+  4:  r6 = 3
+  ...
+  8: [state pruning point]
+  ...
+  /* u32 spill/fill */
+  10: *(u32 *)(r10 - 8) = r6
+  11: r8 = *(u32 *)(r10 - 8)
+  12: r0 = 0
+  13: if r8 == 3 goto pc+1
+  14: r0 = 1
+  15: exit
+
+The verifier first walks the path with R6=3. Given the support for <8B
+spill/fills, at instruction 13, it knows the condition is true and skips
+instruction 14. At that point, the backtracking logic kicks in but stops
+at the fill instruction since it only propagates the precision bit for
+8B spill/fill. When the verifier then walks the path with R6=2, it will
+consider it safe at instruction 8 because R6 is not marked as needing
+precision. Instruction 14 is thus never walked and is then incorrectly
+removed as 'dead code'.
+
+It's also possible to lead the verifier to accept e.g. an out-of-bound
+memory access instead of causing an incorrect dead code elimination.
+
+This regression was found via Cilium's bpf-next CI where it was causing
+a conntrack map update to be silently skipped because the code had been
+removed by the verifier.
+
+This commit fixes it by enabling support for <8B spill/fills in the
+bactracking logic. In case of a <8B spill/fill, the full 8B stack slot
+will be marked as needing precision. Then, in __mark_chain_precision,
+any tracked register spilled in a marked slot will itself be marked as
+needing precision, regardless of the spill size. This logic makes two
+assumptions: (1) only 8B-aligned spill/fill are tracked and (2) spilled
+registers are only tracked if the spill and fill sizes are equal. Commit
+ef979017b837 ("bpf: selftest: Add verifier tests for <8-byte scalar
+spill and refill") covers the first assumption and the next commit in
+this patchset covers the second.
+
+Fixes: 354e8f1970f8 ("bpf: Support <8-byte scalar spill and refill")
+Signed-off-by: Paul Chaignon <paul@isovalent.com>
+Signed-off-by: Alexei Starovoitov <ast@kernel.org>
+---
+ kernel/bpf/verifier.c | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/kernel/bpf/verifier.c b/kernel/bpf/verifier.c
+index f3001937bbb9..f2f1ed34cfe9 100644
+--- a/kernel/bpf/verifier.c
++++ b/kernel/bpf/verifier.c
+@@ -2379,8 +2379,6 @@ static int backtrack_insn(struct bpf_verifier_env *env, int idx,
+ 		 */
+ 		if (insn->src_reg != BPF_REG_FP)
+ 			return 0;
+-		if (BPF_SIZE(insn->code) != BPF_DW)
+-			return 0;
+ 
+ 		/* dreg = *(u64 *)[fp - off] was a fill from the stack.
+ 		 * that [fp - off] slot contains scalar that needs to be
+@@ -2403,8 +2401,6 @@ static int backtrack_insn(struct bpf_verifier_env *env, int idx,
+ 		/* scalars can only be spilled into stack */
+ 		if (insn->dst_reg != BPF_REG_FP)
+ 			return 0;
+-		if (BPF_SIZE(insn->code) != BPF_DW)
+-			return 0;
+ 		spi = (-insn->off - 1) / BPF_REG_SIZE;
+ 		if (spi >= 64) {
+ 			verbose(env, "BUG spi %d\n", spi);
+-- 
+2.25.1
+

--- a/provision/ubuntu/kernel-next.sh
+++ b/provision/ubuntu/kernel-next.sh
@@ -27,6 +27,11 @@ rm -rf pahole
 
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/
 
+# Apply local patches
+git config --global user.email "maintainer@cilium.io"
+git config --global user.name  "Cilium Maintainers"
+git am /tmp/*.patch
+
 # Build kernel
 cp /boot/config-`uname -r` .config
 yes "" | make localyesconfig && make prepare


### PR DESCRIPTION
The latest bpf-next sources include a bug introduced by [354e8f1970f8](https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf.git/commit/?id=354e8f1970f8) ("bpf: Support <8-byte scalar spill and refill") that causes incorrect dead code elimination on Cilium's datapath. That in turn causes CT state entries to be missing and reply packets to be dropped in CI tests.

This regression is fixed in [345e004d0233](https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf.git/commit/?id=345e004d023343d38088fdfea39688aa11e06ccf) ("bpf: Fix incorrect state pruning for <8B spill/fill") includes in this commit. We need to include it as a separate patch until it lands in bpf-next (currently in bpf).