### PR TITLE
provision: Update net-next kernel config for Istio

### DIFF
--- a/provision/ubuntu/kernel-next.sh
+++ b/provision/ubuntu/kernel-next.sh
@@ -134,6 +134,9 @@ yes "" | make localyesconfig && make prepare
 ./scripts/config --module CONFIG_DUMMY
 ./scripts/config --module CONFIG_BONDING
 ./scripts/config --module CONFIG_VLAN_8021Q
+# Needed for Istio.
+./scripts/config --module CONFIG_NETFILTER_XT_MATCH_OWNER
+./scripts/config --module CONFIG_NETFILTER_XT_TARGET_CONNMARK
 # Needed for NFS shared folders.
 ./scripts/config --module CONFIG_NFS_FS
 ./scripts/config --module CONFIG_NFS_V3


### PR DESCRIPTION
Istio uses the `owner` iptables module and the `CONNMARK` target. These kernel configs are therefore necessary to run the K8sIstio test in Cilium CI.

This change was tested locally using the K8sIstio test from cilium/cilium.