### PR TITLE
Revert "Update to kernel 4.19.210"

### DIFF
--- a/cilium-ubuntu-4.19.json
+++ b/cilium-ubuntu-4.19.json
@@ -75,7 +75,7 @@
       ]
     },{
       "type": "shell",
-      "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}' 0419210 202110091331",
+      "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}' 0419190 202105070933",
       "expect_disconnect": true,
       "scripts": [
           "provision/ubuntu/kernel.sh"


### PR DESCRIPTION
This reverts commit 29fcc296cac7bc42f4b366a6054d169e2fbaee68.

From that commit:

    A new complexity issue was reported in cilium/cilium with default
    configuration on kernel 4.19.208+. We can update our 4.19 image to
    try and catch it if it affects Cilium's master.

Spoiler: it does. And since we don't have a workaround, we need to revert this kernel update for now. The complexity issue is tracked at https://github.com/cilium/cilium/issues/17647.