### PR TITLE
Use bpftool mirror instead of building from bpf-next repository

### DIFF
--- a/cilium-ubuntu-4.19.json
+++ b/cilium-ubuntu-4.19.json
@@ -69,9 +69,7 @@
       "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
       "expect_disconnect": true,
       "scripts": [
-          "provision/ubuntu/netperf.sh",
-          "provision/ubuntu/kernel-next-bpftool.sh",
-          "provision/ubuntu/kernel-next-clean.sh"
+          "provision/ubuntu/netperf.sh"
       ]
     },{
       "type": "shell",

--- a/cilium-ubuntu-5.4.json
+++ b/cilium-ubuntu-5.4.json
@@ -70,9 +70,7 @@
       "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
       "expect_disconnect": true,
       "scripts": [
-          "provision/ubuntu/netperf.sh",
-          "provision/ubuntu/kernel-next-bpftool.sh",
-          "provision/ubuntu/kernel-next-clean.sh"
+          "provision/ubuntu/netperf.sh"
       ]
     },{
       "type": "shell",

--- a/cilium-ubuntu-next.json
+++ b/cilium-ubuntu-next.json
@@ -71,13 +71,7 @@
       "expect_disconnect": true,
       "scripts": [
           "provision/ubuntu/netperf.sh",
-          "provision/ubuntu/kernel-next-bpftool.sh"
-      ]
-    },{
-      "type": "shell",
-      "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
-      "expect_disconnect": true,
-      "scripts": [
+          "provision/ubuntu/kernel-next-download.sh",
           "provision/ubuntu/kernel-next-tools.sh"
       ]
     },{

--- a/cilium-ubuntu.json
+++ b/cilium-ubuntu.json
@@ -69,9 +69,7 @@
       "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'",
       "expect_disconnect": true,
       "scripts": [
-          "provision/ubuntu/netperf.sh",
-          "provision/ubuntu/kernel-next-bpftool.sh",
-          "provision/ubuntu/kernel-next-clean.sh"
+          "provision/ubuntu/netperf.sh"
       ]
     },{
       "type": "shell",

--- a/provision/ubuntu/install.sh
+++ b/provision/ubuntu/install.sh
@@ -6,6 +6,7 @@ source "${ENV_FILEPATH}"
 export 'IPROUTE_BRANCH'=${IPROUTE_BRANCH:-"libbpf-static-data"}
 export 'IPROUTE_GIT'=${IPROUTE_GIT:-https://github.com/cilium/iproute2}
 export 'LIBBPF_GIT'=${LIBBPF_GIT:-https://github.com/cilium/libbpf}
+export 'BPFTOOL_GIT'=${BPFTOOL_GIT:-https://github.com/libbpf/bpftool}
 export 'GUESTADDITIONS'=${GUESTADDITIONS:-""}
 export 'NETNEXT'="${NETNEXT:-false}"
 
@@ -103,7 +104,7 @@ sudo apt-get install -y conntrack
 # Documentation dependencies
 sudo -H pip3 install -r https://raw.githubusercontent.com/cilium/cilium/master/Documentation/requirements.txt
 
-# libbpf and iproute2
+# libbpf, bpftool, and iproute2
 cd /tmp
 git clone --depth=1 ${LIBBPF_GIT}
 cd /tmp/libbpf/src
@@ -113,6 +114,13 @@ make -j "$(getconf _NPROCESSORS_ONLN)"
 # libbpf's Makefile.
 sudo PREFIX="/usr" LIBDIR="/usr/lib/x86_64-linux-gnu" make install
 sudo ldconfig
+
+sudo apt-get install -y libbfd-dev libcap-dev libelf-dev
+cd /tmp
+git clone --depth=1 --recurse-submodules ${BPFTOOL_GIT}
+cd /tmp/bpftool/src
+make -j "$(getconf _NPROCESSORS_ONLN)"
+sudo make install
 
 cd /tmp
 git clone -b ${IPROUTE_BRANCH} ${IPROUTE_GIT}

--- a/provision/ubuntu/kernel-next-download.sh
+++ b/provision/ubuntu/kernel-next-download.sh
@@ -11,7 +11,3 @@ sudo apt-get install -y --allow-downgrades \
 git clone --depth 1 git://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git $HOME/k
 cd $HOME/k
 git --no-pager log -n1
-
-cd $HOME/k/tools/bpf/bpftool
-make
-sudo make install


### PR DESCRIPTION
There is now a GitHub mirror available for bpftool. Let's use it to download and compile the tool, instead of downloading the entire kernel repository for all images.

This should not save any disk space or boot time on the VM themselves, but should accelerate the builds (except for ubuntu-next, where building from the kernel sources that were already downloaded or from the mirror makes little difference).
