### PR TITLE
provision: Remove package unattended-upgrades from Ubuntu

### DIFF
--- a/provision/ubuntu/install.sh
+++ b/provision/ubuntu/install.sh
@@ -38,9 +38,8 @@ if [ "${NETNEXT}" == "true" ]; then
     sudo rm $(which mount.vboxsf)
 fi
 
-# Disable unattended-upgrades to prevent it from holding the dpkg frontend lock
-sudo systemctl disable unattended-upgrades.service
-sudo systemctl stop unattended-upgrades.service
+# Remove unattended-upgrades to prevent it from holding the dpkg frontend lock
+sudo apt-get remove --purge -y unattended-upgrades
 
 echo "Provision a new server"
 sudo apt-get update


### PR DESCRIPTION
In the past, we added to the ubuntu/install.sh script some commands to disable the unattended-upgrades service when provisioning the VM. However, it seems that something is still re-enabling the unattended-upgrades, which sometimes hinders the launch of the VM because the apt lock is held by that process.

As an additional step to prevent the launch of unattended-upgrades, let's remove the package from the system.
