### PR TITLE
Revert "next: Fix perf build"

### DIFF
--- a/provision/ubuntu/kernel-next-download.sh
+++ b/provision/ubuntu/kernel-next-download.sh
@@ -11,9 +11,3 @@ sudo apt-get install -y --allow-downgrades \
 git clone --depth 1 git://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git $HOME/k
 cd $HOME/k
 git --no-pager log -n1
-# We need this commit to fix a regression in perf's build.
-git remote add tip https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git
-git fetch tip
-git config --global user.email "maintainer@cilium.io"
-git config --global user.name "Cilium Maintainers"
-git cherry-pick d4ff92659244a4783e424fa41b6f83645d8920c1


### PR DESCRIPTION
This reverts commit 4446884838718675da4ec69718fd52966c6a446c.

The upstream commit was pulled in bpf-next so we don't need to cherry-pick it anymore.