### PR TITLE
provision: Don't check for updates with apt-get

### DIFF
--- a/provision/ubuntu/install.sh
+++ b/provision/ubuntu/install.sh
@@ -40,6 +40,8 @@ fi
 
 # Remove unattended-upgrades to prevent it from holding the dpkg frontend lock
 sudo apt-get remove --purge -y unattended-upgrades
+# and change the configuration to not even check for potential updates.
+sed -i 's/Update-Package-Lists "1"/Update-Package-Lists "0"/' /etc/apt/apt.conf.d/10periodic
 
 echo "Provision a new server"
 sudo apt-get update


### PR DESCRIPTION
Commit 18b7307 ("provision: Remove package unattended-upgrades from Ubuntu") attempted to prevent apt-get from holding the update lock as that can cause the VM provisioning to fail in CI.

It seems it wasn't enough however as the issue is still happening. This pull request attempts an additional fix by not even checking if updates exist.

Related: https://github.com/cilium/packer-ci-build/issues/315.