### PR TITLE
provision: disable apt-daily and apt-daily-upgrade services

### DIFF
--- a/provision/ubuntu/install.sh
+++ b/provision/ubuntu/install.sh
@@ -40,8 +40,11 @@ fi
 
 # Remove unattended-upgrades to prevent it from holding the dpkg frontend lock
 sudo apt-get remove --purge -y unattended-upgrades
-# and change the configuration to not even check for potential updates.
+# change the configuration to not even check for potential updates
 sed -i 's/Update-Package-Lists "1"/Update-Package-Lists "0"/' /etc/apt/apt.conf.d/10periodic
+# and disable apt-daily-upgrade and apt-daily jobs
+sudo systemctl disable apt-daily-upgrade.timer
+sudo systemctl disable apt-daily.timer
 
 echo "Provision a new server"
 sudo apt-get update


### PR DESCRIPTION
Disable apt-daily-upgrade and apt-daily jobs to avoid APT holding the
locks and occasionally making the VMs fail to provision correctly

Fixes: #315