### PR TITLE
provision: update Go to 1.18.1, golangci-lint to 1.45.2

### DIFF
--- a/provision/env.bash
+++ b/provision/env.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export GOLANG_VERSION="1.18"
+export GOLANG_VERSION="1.18.1"
 export ETCD_VERSION="v3.1.0"
 export CONTAINERD_VERSION="1.3.4"
 export HUBBLE_VERSION="0.9.0"

--- a/provision/golang.sh
+++ b/provision/golang.sh
@@ -8,6 +8,6 @@ sudo -u vagrant -E bash -c "mkdir -p ${GOPATH} && \
 go install github.com/google/gops@latest && \
 go install github.com/subfuzion/envtpl/cmd/envtpl@latest"
 
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b ${GOPATH}/bin/ v1.42.1
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b ${GOPATH}/bin/ v1.45.2
 
 sudo -E ln -s "${GOPATH}/bin/"* /usr/bin


### PR DESCRIPTION
Matching the versions currently used on Cilium `master` branch.