### PR TITLE
Revert "provision: add OVERLAY_FS module"

### DIFF
--- a/provision/ubuntu/kernel-next.sh
+++ b/provision/ubuntu/kernel-next.sh
@@ -133,8 +133,6 @@ yes "" | make localyesconfig && make prepare
 ./scripts/config --module CONFIG_NFS_V3
 ./scripts/config --module CONFIG_NFSD
 ./scripts/config --enable CONFIG_NFSD_V3
-# Needed for container runtimes that are not docker
-./scripts/config --module CONFIG_OVERLAY_FS
 
 yes "" | make config
 make -j$(nproc) deb-pkg


### PR DESCRIPTION
This reverts pull request https://github.com/cilium/packer-ci-build/pull/327.

This kernel config is not needed after all.