### PR TITLE
Revert "Revert "provision: add OVERLAY_FS module""

### DIFF
--- a/provision/ubuntu/containerd.sh
+++ b/provision/ubuntu/containerd.sh
@@ -25,9 +25,6 @@ oom_score = 0
   max_recv_message_size = 16777216
   max_send_message_size = 16777216
 
-[plugins.cri.containerd]
-  snapshotter = "native"
-
 [debug]
   address = ""
   uid = 0

--- a/provision/ubuntu/kernel-next.sh
+++ b/provision/ubuntu/kernel-next.sh
@@ -133,6 +133,8 @@ yes "" | make localyesconfig && make prepare
 ./scripts/config --module CONFIG_NFS_V3
 ./scripts/config --module CONFIG_NFSD
 ./scripts/config --enable CONFIG_NFSD_V3
+# Needed for container runtimes that are not docker
+./scripts/config --module CONFIG_OVERLAY_FS
 
 yes "" | make config
 make -j$(nproc) deb-pkg


### PR DESCRIPTION
This reverts commit 89f73739a9f8c171cc9bf80fb98875357cdfe62a.

This kernel config is needed after all.

Signed-off-by: André Martins <andre@cilium.io>