### PR TITLE
Removed old iproute2 executable

### DIFF
--- a/provision/ubuntu/install.sh
+++ b/provision/ubuntu/install.sh
@@ -134,6 +134,7 @@ PKG_CONFIG_PATH="/usr/lib64/pkgconfig"  \
 PKG_CONFIG="pkg-config --define-prefix" \
 ./configure
 make -j `getconf _NPROCESSORS_ONLN`
+rm -r /usr/bin/ip
 make install
 rm -rf /tmp/iproute2
 


### PR DESCRIPTION
Apparently when installing our custom fork of iproute2, the compiled
executable is installed in `/usr/sbin` but the old iproute2 it is
supposed to overwrite still exists in `/usr/bin`. This is no issues as
long as `/usr/sbin` is positioned earlier in the `PATH` env var. But
this is not always the case.

This commit removes the old iproute2 executable so the new executable is
always used.

Signed-off-by: Dylan Reimerink <dylan.reimerink@isovalent.com>