### PR TITLE
Update the kernel for 5.4

### DIFF
--- a/cilium-ubuntu-5.4.json
+++ b/cilium-ubuntu-5.4.json
@@ -74,7 +74,7 @@
       ]
     },{
       "type": "shell",
-      "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}' 050410 202001091038",
+      "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}' 0504190 202204200839",
       "expect_disconnect": true,
       "scripts": [
           "provision/ubuntu/kernel.sh"

--- a/provision/ubuntu/kernel.sh
+++ b/provision/ubuntu/kernel.sh
@@ -18,11 +18,6 @@ micro=$(echo ${canonicalString:4} | sed 's/^0*//')
 
 echo $major.$minor.$micro
 
-if [[ "$major" == "5" && "$minor" == "4" ]]; then
-	# Packages for this kernel are kept in the root directory
-	subdir=""
-fi
-
 if [[ "$major" == "4" && "$minor" == "19" ]] || [[ "$major" == "5" && "$minor" == "4" ]] ; then
 	# kernel debs have the -unsigned suffix
 	imgsuffix="-unsigned"


### PR DESCRIPTION
This commit updates to the latest kernel with a round number (round number packages are kept longer on the hosting server), 5.4.190.