### PR TITLE
Add mfridman/tparse for better Go test output

### DIFF
--- a/provision/golang.sh
+++ b/provision/golang.sh
@@ -6,7 +6,8 @@ set -e
 
 sudo -u vagrant -E bash -c "mkdir -p ${GOPATH} && \
 go install github.com/google/gops@latest && \
-go install github.com/subfuzion/envtpl/cmd/envtpl@latest"
+go install github.com/subfuzion/envtpl/cmd/envtpl@latest && \
+go install github.com/mfridman/tparse@latest"
 
 curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b ${GOPATH}/bin/ v1.45.2
 


### PR DESCRIPTION
Privileged tests will benefit from printing in a table to make it easier
for developres to parse the output and understand how long tests take.
Add mfridman/tparse to help do this in the VM environment.
