### PR TITLE
provision: Prepull all Cilium images

### DIFF
--- a/provision/pull-images.sh
+++ b/provision/pull-images.sh
@@ -45,7 +45,14 @@ if [ -z "${NAME_PREFIX}" ]; then
         gcr.io/google_samples/gb-redis-follower:v2 \
         k8s.gcr.io/coredns/coredns:v1.8.3 \
         quay.io/cilium/alpine-curl:v1.3.0 \
-        quay.io/cilium/cilium-builder:134f18bc4fc7c627e933308398451122be64df62 \
+        quay.io/cilium/cilium-bpftool:78448c1a37ff2b790d5e25c3d8b8ec3e96e6405f \
+        quay.io/cilium/cilium-builder:6284fc1a4c7206b8bee0d9309e0b6e331f564618 \
+        quay.io/cilium/cilium-envoy:e90612180b82d07c124bbf8e1ffe94a8d603f8ae \
+        quay.io/cilium/cilium-iproute2:02c29c971c01f0b9a7b916327f0caedd83820c18 \
+        quay.io/cilium/cilium-llvm:547db7ec9a750b8f888a506709adb41f135b952e \
+        quay.io/cilium/cilium-runtime:05ac87c6a2ef4f24e6ba9acf8b06e8c2362cab2f \
+        quay.io/cilium/image-compilers:e847f4176cb42ae27fa459a10df6721c43702b64 \
+        quay.io/cilium/image-tester:c37f768323abfba87c90cd9c82d37136183457bc \
         quay.io/cilium/cilium-envoy:9c0d933166ba192713f9e2fc3901f788557286ee \
         quay.io/cilium/istio_pilot:1.10.4 \
         quay.io/cilium/istio_proxy:1.10.4 \


### PR DESCRIPTION
Every time we run the end-to-end tests, we pull those images because they are not cached in the VMs. Let's fix that.