### PR TITLE
provision: Export HUBBLE_SERVER socket

### DIFF
--- a/provision/ubuntu/install.sh
+++ b/provision/ubuntu/install.sh
@@ -214,6 +214,7 @@ wget "https://github.com/cilium/hubble/releases/download/v${HUBBLE_VERSION}/hubb
 wget "https://github.com/cilium/hubble/releases/download/v${HUBBLE_VERSION}/hubble-linux-amd64.tar.gz.sha256sum"
 sha256sum --check hubble-linux-amd64.tar.gz.sha256sum || exit 1
 sudo tar -xf "hubble-linux-amd64.tar.gz" -C /usr/bin hubble
+sudo bash -c "echo 'HUBBLE_SERVER=unix:///var/run/cilium/hubble.sock' >> /etc/environment"
 
 # Clean all downloaded packages
 sudo apt-get -y clean


### PR DESCRIPTION
Running Hubble in the VMs fails with the following error message, because Relay is not deployed and there is nothing to listen to at the default address:

    failed to connect to 'localhost:4245': connection error: desc = "transport: error while dialing: dial tcp 127.0.0.1:4245: connect: connection refused"`

We can have Hubble working on its own by exporting the `HUBBLE_SERVER` environment variable and making it point to the Hubble socket.

Let's use /etc/environment so that the variable is exported for all users, and Hubble remains accessible when working as root.
