### PR TITLE
CODEOWNERS: update teams following removal of non-sig teams

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,12 +1,12 @@
 # Code owners groups used in this repository and a brief description of their areas:
-# @cilium/bpf                BPF Data Path
 # @cilium/ci-structure       Continuous integration, testing
 # @cilium/contributing       Developer documentation & tools
 # @cilium/loader             All related to LLVM, bpftool, Cilium loader, templating, etc.
+# @cilium/sig-datapath       BPF Data Path
 
 # The following filepaths should be sorted so that more specific paths occur
 # after the less specific paths, otherwise the ownership for the specific paths
 # is not properly picked up in Github.
 * @cilium/ci-structure
 /CODEOWNERS @cilium/contributing
-/provision/ubuntu/kernel-next* @cilium/bpf @cilium/loader
+/provision/ubuntu/kernel-next* @cilium/sig-datapath @cilium/loader


### PR DESCRIPTION
Several teams were removed in favor of their sig-xxx equivalents. Update
CODEOWNERS accordingly.