### PR TITLE
provision: bump 4.9 kernel package to 4.9.326

### DIFF
--- a/provision/ubuntu/kernel.sh
+++ b/provision/ubuntu/kernel.sh
@@ -2,13 +2,13 @@
 
 set -e
 
-# This script installs kernel 4.9.258 and when it finished sets the installed
+# This script installs kernel 4.9.326 and when it finished sets the installed
 # kernel as default in the grub.
 
 mkdir /tmp/deb
 cd /tmp/deb
 
-canonicalString=${1:-0409270}
+canonicalString=${1:-0409326}
 timestamp=${2:-202105261032}
 subdir="amd64/"
 


### PR DESCRIPTION
This version contains a fix [1], [2] (courtesy of Quentin) for a verifier
issue [3] we've been seeing in Cilium CI.

[1] https://lore.kernel.org/stable/20220812092211.14446-1-quentin@isovalent.com/t/#u
[2] https://lore.kernel.org/stable/20220812092211.14446-1-quentin@isovalent.com/t/#u
[3] https://github.com/cilium/cilium/issues/20288

/cc @qmonnet