### PR TITLE
provision: Bump 4.9 kernel packages (4.9.326, to fix a kernel bug)

### DIFF
--- a/provision/ubuntu/kernel.sh
+++ b/provision/ubuntu/kernel.sh
@@ -2,14 +2,14 @@
 
 set -e
 
-# This script installs kernel 4.9.258 and when it finished sets the installed
+# This script installs kernel 4.9.* and then sets the installed
 # kernel as default in the grub.
 
 mkdir /tmp/deb
 cd /tmp/deb
 
-canonicalString=${1:-0409270}
-timestamp=${2:-202105261032}
+canonicalString=${1:-0409326}
+timestamp=${2:-202208251224}
 subdir="amd64/"
 
 major=$(echo ${canonicalString:0:2} | sed 's/^0*//')


### PR DESCRIPTION
We have been hitting a kernel bug on 4.9 for the verifier tests. An underflow on the memlock rlimit counter, caused by the reallocation of BPF programs not updating the charged values, makes the counter go under zero and convert into a huge value, [blocking all further loads of BPF objects][0].

This has been [fixed in kernel 4.10][1], and was backported at last in 4.9.326.

Note: We need to update again soon towards a patch version which is a multiple of 5 (4.9.330), given that other releases are not kept for a long time, see commit b956b0726059 ("Bump kernel 4.19 package").

[0]: https://github.com/cilium/cilium/issues/20288
[1]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=5ccb071e97fbd9ffe623a0d3977cc6d013bee93c
