### PR TITLE
Enable kernel configs for kube-proxy

### DIFF
--- a/provision/ubuntu/kernel-next.sh
+++ b/provision/ubuntu/kernel-next.sh
@@ -97,6 +97,13 @@ yes "" | make localyesconfig && make prepare
 ./scripts/config --module CONFIG_VXLAN
 ./scripts/config --module CONFIG_GENEVE
 ./scripts/config --module CONFIG_NET_SCH_FQ
+# Needed by kube-proxy
+./scripts/config --enable CONFIG_IP_NF_TARGET_REJECT
+./scripts/config --enable CONFIG_IP6_NF_TARGET_REJECT
+./scripts/config --module CONFIG_NETFILTER_XT_MATCH_STATISTIC
+./scripts/config --module CONFIG_IP_VS_RR
+./scripts/config --module CONFIG_IP_VS_WRR
+./scripts/config --module CONFIG_IP_VS_SH
 # Needed for Cilium's IPsec implementation.
 ./scripts/config --enable CONFIG_XFRM
 ./scripts/config --enable CONFIG_XFRM_OFFLOAD


### PR DESCRIPTION
When I first build the minimal kernel config, I think I only tested it by running the end-to-end tests which for, net-next CI job, run with KPR=strict. Thus, kube-proxy was probably not, or barely, tested.

This commits adds a few kernel configs that are currently causing errors for kube-proxy in the development VM.

Reported-by: Maxim Mikityanskiy <maxim@isovalent.com>
Signed-off-by: Paul Chaignon <paul@cilium.io>