### PR TITLE
Update patch version used for 5.4 kernel

### DIFF
--- a/cilium-ubuntu-5.4.json
+++ b/cilium-ubuntu-5.4.json
@@ -74,7 +74,7 @@
       ]
     },{
       "type": "shell",
-      "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}' 0504190 202204200839",
+      "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}' 0504220 202210261259",
       "expect_disconnect": true,
       "scripts": [
           "provision/ubuntu/kernel.sh"


### PR DESCRIPTION
We can't update 4.19 because we have a complexity issue there. 4.9 is already using the latest version (considering we have to use a rounded version or they get recycled quickly).