### PR TITLE
provision: use registry.k8s.io

### DIFF
--- a/provision/pull-images.sh
+++ b/provision/pull-images.sh
@@ -36,9 +36,7 @@ if [ -z "${NAME_PREFIX}" ]; then
         docker.io/library/redis:6.0.5 \
         docker.io/networkstatic/iperf3@sha256:e9bbc8312edff13e2ecccad0907db4b35119139e133719138108955cf07f0683 \
         docker.io/wurstmeister/kafka:2.11-0.11.0.3 \
-        gcr.io/google-samples/gb-frontend:v6 \
-        gcr.io/google_samples/gb-redis-follower:v2 \
-        k8s.gcr.io/coredns/coredns:v1.8.3 \
+        registry.k8s.io/coredns/coredns:v1.8.3 \
         quay.io/cilium/alpine-curl:v1.3.0 \
         quay.io/cilium/cilium-bpftool:78448c1a37ff2b790d5e25c3d8b8ec3e96e6405f \
         quay.io/cilium/cilium-builder:6284fc1a4c7206b8bee0d9309e0b6e331f564618 \


### PR DESCRIPTION
Use registry.k8s.io to pull the coredns image, see https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/ for details.

The gb-frontend and gb-redis-follower images are no longer used by cilium/cilium CI, so they can be dropped.